### PR TITLE
[v1.8.0] Add content from community doc PRs (Aug to Sep 2024)

### DIFF
--- a/docs/version-1.7.0/modules/en/pages/upgrades/upgrades.adoc
+++ b/docs/version-1.7.0/modules/en/pages/upgrades/upgrades.adoc
@@ -12,13 +12,11 @@ Longhorn only allows upgrades from supported versions. When you attempt to upgra
 
 Moreover, Longhorn does not support downgrades to earlier versions. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, or removal.
 
-____
-*Warning*:
-
+[CAUTION]
+====
 * Once you successfully upgrade to v1.7.0, you will not be allowed to revert to the previously installed version.
-* The Downgrade Prevention feature was introduced in v1.5.0 so Longhorn is unable to prevent downgrade attempts in older versions.
-However, downgrading is completely unsupported and is therefore not recommended.
-____
+* Downgrading is completely unsupported and is therefore not recommended.
+====
 
 The following table outlines the supported upgrade paths.
 
@@ -36,7 +34,7 @@ The following table outlines the supported upgrade paths.
 | ✓
 | v1.5.0  to  v1.5.1
 
-| x.yfootnote:lastMinorVersion[Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.].*
+| x.y[^lastMinorVersion].*
 | (x+1).y.*
 | ✓
 | v1.30.0 to  v2.0.0
@@ -50,17 +48,12 @@ The following table outlines the supported upgrade paths.
 | x.(y+1).*
 | X
 | v1.2.6  to  v1.5.1
-
-| x.y.*
-| x.(y-1).*
-| X
-| v1.6.0  to  v1.5.1
-
-| x.y.*
-| x.y.(*-1)
-| X
-| v1.5.1  to  v1.5.0
 |===
+
+[IMPORTANT]
+====
+Longhorn only allows upgrades from patch versions of the last minor release before the new major version. For example, if v1.7.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.7.0 to any patch version of v2.0.
+====
 
 == Upgrading Longhorn
 

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -186,6 +186,12 @@ To apply the storage network to existing RWX volumes, you must detach the volume
 
 For more information, see https://github.com/longhorn/longhorn/issues/8184[Issue #8184].
 
+## Operating Systems and Distributions
+
+### Talos Linux
+
+Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux clusters. To use V2 volumes, ensure that all nodes meet the V2 Data Engine prerequisites. For more information, see xref:installation-setup/os-distro/talos-linux.adoc#v2-data-engine[Talos Linux Support: V2 Data Engine].
+
 == V2 Data Engine
 
 === Longhorn System Upgrade

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -147,6 +147,10 @@ NOTE: In rare circumstances, it is possible for the failover to become deadlocke
 
 Starting with v1.7.0, Longhorn supports configuration of timeouts for replica rebuilding and snapshot cloning. Before v1.7.0, the replica rebuilding timeout was capped at 24 hours, which could cause failures for large volumes in slow bandwidth environments. The default timeout is still 24 hours but you can adjust it to accommodate different environments. For more information, see xref:longhorn-system/settings.adoc#_long_grpc_timeout[Long gRPC Timeout].
 
+=== Change in Engine Replica Timeout Behavior
+
+In versions earlier than v1.8.0, the xref:longhorn-system/settings.adoc#engine-replica-timeout[Engine Replica Timeout] setting was equally applied to all V1 volume replicas. In v1.8.0, a V1 engine marks the last active replica as failed only after twice the configured number of seconds (timeout value x 2) have passed.
+
 == Data Integrity and Reliability
 
 === Support Periodic and On-Demand Full Backups to Enhance Backup Reliability

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -215,3 +215,7 @@ Snapshots created before Longhorn v1.7.0 may change occasionally. This issue ari
 === Unable To Revert a Volume to a Snapshot Created Before Longhorn v1.7.0
 
 Reverting a volume to a snapshot created before Longhorn v1.7.0 is not supported due to an incorrect UserCreated flag set on the snapshot. The workaround is to back up the existing snapshots before upgrading to Longhorn v1.7.0 and restore them if needed. The bug is fixed in v1.7.0, and more information can be found https://github.com/longhorn/longhorn/issues/9054[here].
+
+=== Disaster Recovery Volumes
+
+Longhorn v1.8.0 supports disaster recovery volumes.

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -55,9 +55,27 @@ machine:
 
 For detailed instructions, see the Talos documentation on https://www.talos.dev/v1.6/talos-guides/configuration/editing-machine-configuration/[Editing Machine Configuration].
 
-== Limitations
+== V2 Data Engine
 
-* Exclusive to v1 data volume: currently, within a Talos Linux cluster, {longhorn-product-name} only supports v1 data volume. The v2 data volume isn't currently supported in this environment.
+To use V2 volumes, all nodes must meet the V2 Data Engine xref:../../longhorn-system/v2-data-engine/prerequisites.adoc[prerequisites].
+
+```yaml
+machine:
+  sysctls:
+    vm.nr_hugepages: "1024"
+  kernel:
+    modules:
+      - name: nvme_tcp
+      - name: vfio_pci
+#     - name: uio_pci_generic
+```
+
+[NOTE]
+====
+Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
+
+You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see [Issue #9236](https://github.com/siderolabs/talos/issues/9236).
+====
 
 == Talos Linux Upgrades
 

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
@@ -373,8 +373,6 @@ The interval in seconds determines how long Longhorn will wait before re-downloa
 
 [NOTE]
 ====
-
-
 * This recovery only works for the backing image of which the creation type is `download`.
 * File state `unknown` means the related manager pods on the pod is not running or the node itself is down/disconnected.
 ====
@@ -387,13 +385,19 @@ ____
 
 The default minimum number of backing image copies Longhorn maintains.
 
-=== Engine to Replica Timeout
+=== Engine Replica Timeout
 
 ____
 Default: `8`
 ____
 
-The value in seconds specifies the timeout of the engine to the replica(s), and the value should be between 8 to 30 seconds.
+Number of seconds a V1 Data Engine waits for a replica to respond before marking it as failed. Values between 8 and 30 are allowed. This setting takes effect only when there are outstanding I/O requests.
+
+This setting only applies to additional replicas. A V1 engine marks the last active replica as failed only after twice the configured number of seconds (timeout value x 2) have passed. This behavior is intended to balance volume responsiveness with volume availability.
+
+The engine can quickly (after the configured timeout) ignore individual replicas that become unresponsive in favor of other available ones. This ensures future I/O will not be held up.
+
+The engine waits on the last replica (until twice the configured timeout) to prevent unnecessarily crashing as a result of having no available backends.
 
 === Support Bundle Manager Image
 

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/v2-data-engine/features/node-disk-support.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/v2-data-engine/features/node-disk-support.adoc
@@ -22,15 +22,15 @@ Automatic detection of disk drivers simplifies the addition and management of di
 
 == Configure a Disk on Longhorn Node
 
-Longhorn can automatically detect the disk type if `node.disks[i].diskDriver` is set to `auto`, optimizing storage performance. The detection and management will be as follows:
+Longhorn automatically detects the disk type if `node.spec.disks[i].diskDriver` is set to `auto`, optimizing storage performance. The detection and management are as follows:
 
-* NVMe Disk: managed by spdk_tgt using the nvme bdev driver, and `node.disks[i].diskDriver` will be set to `nvme`.
-* VirtIO Disk: managed by spdk_tgt using the virtio bdev driver, and `node.disks[i].diskDriver` will be set to `virtio-blk`.
-* Other Disks: managed by spdk_tgt using the aio bdev driver, and `node.disks[i].diskDriver` will be set to `aio`.
+* NVMe Disk: managed by spdk_tgt using the nvme bdev driver, and `node.status.diskStatus[i].diskDriver` is set to `nvme`.
+* VirtIO Disk: managed by spdk_tgt using the virtio bdev driver, and `node.status.diskStatus[i].diskDriver` is set to `virtio-blk`.
+* Other Disks: managed by spdk_tgt using the aio bdev driver, and `node.status.diskStatus[i].diskDriver` is set to `aio`.
 
-Alternatively, users can manually set `node.disks[i].diskDriver` to `aio` to force the use of the aio bdev driver.
+Alternatively, users can manually set `node.spec.disks[i].diskDriver` to `aio` to force the use of the aio bdev driver.
 
-To support NVMe and VirtIO disks, you need to find the BDF (Bus, Device, Function) of the disk as a disk path that will be added to the Longhorn node. The following examples provide an introduction to configuring NVMe disks, VirtIO disks, and others.
+To support NVMe and VirtIO disks, you need to find the BDF (Bus, Device, Function) of the disk as a disk path to be added to the Longhorn node. The following examples provide an introduction to configuring NVMe disks, VirtIO disks, and others.
 
 ____
 *Note*
@@ -91,7 +91,7 @@ If you add the disk using a different path, such as:
    tags: []
 ----
 
-In this case, the disk will be managed by the aio bdev driver, and the `node.disks[i].diskDriver` will be set to `aio`.
+In this case, the disk will be managed by the aio bdev driver, and the `node.status.diskStatus[i].diskDriver` is set to `aio`.
 ____
 
 === Using VirtIO Disks
@@ -149,7 +149,7 @@ If you add the disk using a different path, such as:
    tags: []
 ----
 
-In this case, the disk will be managed by the aio bdev driver, and the `node.disks[i].diskDriver` will be set to `aio`.
+In this case, the disk will be managed by the aio bdev driver, and the `node.status.diskStatus[i].diskDriver` is set to `aio`.
 ____
 
 === Using AIO Disks
@@ -169,7 +169,7 @@ When neither NVMe nor VirtIO drivers can manage a disk, Longhorn will default to
    tags: []
 ----
 
-. Check node.status.diskStatus. The disk should be detected without errors, and the `node.disks[i].diskDriver` will be set to aio.
+. Check node.status.diskStatus. The disk should be detected without errors, and the `node.status.diskStatus[i].diskDriver` is set to `aio`.
 
 == History
 

--- a/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
+++ b/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
@@ -158,11 +158,11 @@
 
 | longhorn_backup_actual_size_bytes
 | Actual size of this backup
-| longhorn_backup_actual_size_bytes{backup="backup-4ab66eca0d60473e",volume="testvol"} 6.291456e+07
+| longhorn_backup_actual_size_bytes{backup="backup-4ab66eca0d60473e",volume="testvol", recurring_job="backup"} 6.291456e+07
 
 | longhorn_backup_state
 | State of this backup: 0=New, 1=Pending, 2=InProgress, 3=Completed, 4=Error, 5=Unknown
-| longhorn_backup_state{backup="backup-4ab66eca0d60473e",volume="testvol"} 3
+| longhorn_backup_state{backup="backup-4ab66eca0d60473e",volume="testvol", recurring_job=""} 3
 |===
 
 == Snapshot

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/create-recurring-backup-snapshot-job.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/create-recurring-backup-snapshot-job.adoc
@@ -76,7 +76,7 @@ The following parameters should be specified for each recurring job selector:
 * `name`: Name of the recurring job. Do not use duplicate names. And the length of `name` should be no more than 40 characters.
 * `task`: Type of the job. Longhorn supports the following:
  ** `backup`: periodically create snapshots then do backups after cleaning up outdated snapshots
- ** `backup-force-create`: periodically create snapshots the do backups
+ ** `backup-force-create`: periodically create snapshots then do backups
  ** `snapshot`: periodically create snapshots after cleaning up outdated snapshots
  ** `snapshot-force-create`: periodically create snapshots
  ** `snapshot-cleanup`: periodically purge removable snapshots and system snapshots
@@ -123,7 +123,7 @@ Longhorn automatically removes Volume and PVC recurring job labels when a corres
 
 The recurring job can be assigned on the volume detail page. To navigate to the volume detail page, click *Volume* then click the name of the volume.
 
-== Using the `kubectl` command
+== Using kubectl
 
 Add recurring job group:
 
@@ -152,7 +152,7 @@ kubectl -n longhorn-system label volume/<VOLUME-NAME> <RECURRING-JOB-LABEL>-
 # kubectl -n longhorn-system label volume/pvc-8b9cd514-4572-4eb2-836a-ed311e804d2f recurring-job.longhorn.io/backup-
 ----
 
-== With PersistentVolumeClam Using the `kubectl` command
+== With a PersistentVolumeClaim Using kubectl
 
 By default, applying a recurring job to a Persistent Volume Claim (PVC) does not have any effect. You can enable or disable this feature using the recurring job source label.
 

--- a/docs/version-1.8.0/modules/en/pages/upgrades/upgrades.adoc
+++ b/docs/version-1.8.0/modules/en/pages/upgrades/upgrades.adoc
@@ -10,15 +10,13 @@ There are no deprecated or incompatible changes introduced in v{current-version}
 
 Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the operation automatically fails but you can revert to the previously installed version without any service interruption or downtime.
 
-Moreover, Longhorn does not support downgrades to earlier versions. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, or removal.
+Moreover, Longhorn does not support downgrades. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, or removal.
 
-____
-*Warning*:
-
+[CAUTION]
+====
 * Once you successfully upgrade to v1.7.0, you will not be allowed to revert to the previously installed version.
-* The Downgrade Prevention feature was introduced in v1.5.0 so Longhorn is unable to prevent downgrade attempts in older versions.
-However, downgrading is completely unsupported and is therefore not recommended.
-____
+* Downgrading is completely unsupported and is therefore not recommended.
+====
 
 The following table outlines the supported upgrade paths.
 
@@ -36,7 +34,7 @@ The following table outlines the supported upgrade paths.
 | ✓
 | v1.5.0  to  v1.5.1
 
-| x.yfootnote:lastMinorVersion[Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.].*
+| x.y[^lastMinorVersion].*
 | (x+1).y.*
 | ✓
 | v1.30.0 to  v2.0.0
@@ -50,17 +48,12 @@ The following table outlines the supported upgrade paths.
 | x.(y+1).*
 | X
 | v1.2.6  to  v1.5.1
-
-| x.y.*
-| x.(y-1).*
-| X
-| v1.6.0  to  v1.5.1
-
-| x.y.*
-| x.y.(*-1)
-| X
-| v1.5.1  to  v1.5.0
 |===
+
+[IMPORTANT]
+====
+Longhorn only allows upgrades from patch versions of the last minor release before the new major version. For example, if v1.8.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.8.0 to any patch version of v2.0.
+====
 
 == Upgrading Longhorn
 


### PR DESCRIPTION

- [975](https://github.com/longhorn/website/pull/975/): Downgrade path examples
- [977](https://github.com/longhorn/website/pull/977/): Disaster volume recovery support
- [978](https://github.com/longhorn/website/pull/978/): Engine replica timeout
- [980](https://github.com/longhorn/website/pull/980/): Engine replica timeout
- [981](https://github.com/longhorn/website/pull/981/): V2 support for Talos Linux
- [983](https://github.com/longhorn/website/pull/983/): Node disk support
- [984](https://github.com/longhorn/website/pull/984/): Typo errors
- [985](https://github.com/longhorn/website/pull/985/): New label for backup metrics