### PR TITLE
[v1.8.0] Add content from community doc PRs (Sep to Oct 2024)

### DIFF
--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -214,6 +214,8 @@ Before Longhorn v1.7.0, Longhorn block-type disks only supported the SPDK AIO bd
 
 Filesystem trim is supported since Longhorn v1.7.0. If a disk is managed by the SPDK AIO bdev driver, the Trim (UNMAP) operation is not recommended in a production environment (ref). It is recommended to manage a block-type disk with an NVMe bdev driver.
 
+Starting with Longhorn v1.8.0, filesystem trim is blocked when the target V2 volume is in a degraded state. This ensures the reliability of the volume head size during the auto-salvage operation.
+
 === Linux Kernel on Longhorn Nodes
 
 Host machines with Linux kernel 5.15 may unexpectedly reboot when volume-related IO errors occur. To prevent this, update the Linux kernel on Longhorn nodes to version 5.19 or later. For more information, see xref:longhorn-system/v2-data-engine/prerequisites.adoc[Prerequisites]. Version 6.7 or later is recommended for improved system stability.
@@ -229,3 +231,7 @@ Reverting a volume to a snapshot created before Longhorn v1.7.0 is not supported
 === Disaster Recovery Volumes
 
 Longhorn v1.8.0 supports disaster recovery volumes.
+
+=== Auto-salvage Volumes
+
+Longhorn v1.8.0 supports auto-salvage volumes.

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -32,7 +32,7 @@ The functionality of the https://github.com/longhorn/longhorn/blob/master/script
 
 === Supported Kubernetes Versions
 
-Please ensure your Kubernetes cluster is at least v1.21 before upgrading to Longhorn v{current-version} because this is the minimum version Longhorn v{current-version} supports.
+Ensure that Kubernetes v1.25 or later is running on your cluster before upgrading to Longhorn v{current-version}. v1.25 is the minimum version Longhorn v{current-version} supports.
 
 === Pod Security Policies Disabled & Pod Security Admission Introduction
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
@@ -228,16 +228,22 @@ We don't recommend modifying the default StorageClass named `longhorn`, since th
 
 === Replica Node Level Soft Anti-Affinity
 
-____
-Recommend: `false`
-____
+Recommendation: `false`
 
 This setting should be set to `false` in production environment to ensure the best availability of the volume. Otherwise, one node down event may bring down more than one replicas of a volume.
 
 === Allow Volume Creation with Degraded Availability
 
-____
-Recommend: `false`
-____
+Recommendation: `false`
 
 This setting should be set to `false` in production environment to ensure every volume have the best availability when created. Because with the setting set to `true`, the volume creation won't error out even there is only enough room to schedule one replica. So there is a risk that the cluster is running out of the spaces but the user won't be made aware immediately.
+
+=== Replica Auto-Balance
+
+Recommendation: `least-effort`
+
+For production environments, we recommend setting Replica Auto-Balance to `least-effort`. This setting ensures that at least one replica is placed on a different node in each zone, providing extra high availability (HA).
+
+In certain edge cases, you might consider using the `best-effort`, which continuously attempts to evenly distribute replicas across nodes and zones. However, this setting can lead to frequent rebuilds if the cluster is unstable.
+
+For most users, having multiple replicas without Replica Auto-Balance setting is sufficient to achieve basic HA, especially if you prefer to avoid excessive rebuilds and resource usage.

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
@@ -107,6 +107,10 @@ We recommend running your Kubernetes cluster on one of the following versions. T
 |===
 | Release | Released | End-of-life
 
+| 1.30
+| 17 Apr 2024
+| 28 Jun 2025
+
 | 1.28
 | 15 Aug 2023
 | 28 Oct 2024
@@ -114,10 +118,6 @@ We recommend running your Kubernetes cluster on one of the following versions. T
 | 1.27
 | 11 Apr 2023
 | 28 Jun 2024
-
-| 1.26
-| 08 Dec 2022
-| 28 Feb 2024
 |===
 
 Referenced to https://endoflife.date/kubernetes.

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/requirements.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/requirements.adoc
@@ -4,7 +4,7 @@
 Each node in the Kubernetes cluster where {longhorn-product-name} is installed must fulfill the following requirements:
 
 * A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
-* Kubernetes ≥ v1.21
+* Kubernetes v1.25 or later
 * `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. This is necessary, since {longhorn-product-name} relies on `iscsiadm` on the host to provide persistent volumes to Kubernetes. For help installing `open-iscsi`, refer to <<_installing_open_iscsi,this section.>>
 * RWX support requires that each node has a NFSv4 client installed.
  ** For installing a NFSv4 client, refer to <<_installing_nfsv4_client,this section.>>
@@ -339,7 +339,7 @@ Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10", GitCo
 Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10+k3s2", GitCommit:"cb5cb5557f34e240e38c68a8c4ca2506c68b1d86", GitTreeState:"clean", BuildDate:"2023-11-08T03:21:46Z", GoVersion:"go1.20.10", Compiler:"gc", Platform:"linux/amd64"}
 ----
 
-The `Server Version` should be ≥ v1.21.
+The `Server Version` should be v1.25 or later.
 
 [discrete]
 == Installing Cryptsetup and LUKS

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
@@ -165,7 +165,7 @@ ____
 Default: `longhorn-static`
 ____
 
-The `storageClassName` is for persistent volumes (PVs) and persistent volume claims (PVCs) when creating PV/PVC for an existing Longhorn volume. Notice that it's unnecessary for users to create the related StorageClass object in Kubernetes since the StorageClass would only be used as matching labels for PVC bounding purpose. By default 'longhorn-static'.
+The `storageClassName` is for persistent volumes (PVs) and persistent volume claims (PVCs) when creating PV/PVC for an existing Longhorn volume. Notice that it's unnecessary for users to create the related StorageClass object in Kubernetes since the StorageClass would only be used as matching labels for PVC bounding purposes. The "storageClassName" needs to be an existing StorageClass. Only the StorageClass named `longhorn-static` will be created if it does not exist. By default 'longhorn-static'.
 
 === Default Replica Count
 

--- a/docs/version-1.8.0/modules/en/pages/nodes/node-conditions.adoc
+++ b/docs/version-1.8.0/modules/en/pages/nodes/node-conditions.adoc
@@ -5,18 +5,20 @@ Node conditions describe the status of all worker nodes and are used to check th
 
 Node conditions:
 
-* `Ready`: +
-Indicates that the node is ready for Longhorn operations, including that a `longhorn-manager` pod is running on this node, the Kubernetes node is ready, and there is no physical resources pressure.
-* `Schedulable`: +
-Indicated that the node is not cordoned and workload can be scheduled to this node.
-* `MountPropagation`: +
-Indicates that the node supports mount propagation. This is necessary for sharing of volumes mounted by a container with other containers in the same Longhorn pod, or to other Longhorn pods on the same node.
-* `Multipathd`: +
-Confirms if the `multipathd` service is not running on the node, which may affect the pod with the volume startup. See link:https://longhorn.io/kb/troubleshooting-volume-with-multipath/[Troubleshooting: `MountVolume.SetUp failed for volume` due to multipathd on the node].
-* `RequiredPackages`: +
-Checks if all required packages (xref:installation-setup/requirements.adoc#_installing_nfsv4_client[NFS client], xref:installation-setup/requirements.adoc#_installing_open-_scsi[iSCSI tool], xref:installation-setup/requirements.adoc#_installing_cryptsetup_and_luks[cryptsetup], xref:installation-setup/requirements.adoc#_installing_device_mapper_userspace_tool[dmsetup]) exist for Longhorn
-* `NFSClientInstalled`: +
-Identifies if any of the following NFS clients are supported: `v4.2`, `v4.1`, or `v4.0`. NFS client is required for RWX volume and backup.
+* `Ready`: Indicates that the node is ready for Longhorn operations, including that a `longhorn-manager` pod is running on this node, the Kubernetes node is ready, and there is no physical resources pressure.
++
+* `Schedulable`: Indicates that the node is not cordoned and workload can be scheduled to this node.
++
+* `MountPropagation`: Indicates that the node supports mount propagation. This is necessary for sharing of volumes mounted by a container with other containers in the same Longhorn pod, or to other Longhorn pods on the same node.
++ 
+* `Multipathd`: Checks if the `multipathd` service is not running on the node, which may affect the pod with the volume startup. See link:https://longhorn.io/kb/troubleshooting-volume-with-multipath/[Troubleshooting: `MountVolume.SetUp failed for volume` due to multipathd on the node].
+* `RequiredPackages`: Checks if all required packages (xref:installation-setup/requirements.adoc#_installing_nfsv4_client[NFS client], xref:installation-setup/requirements.adoc#_installing_open-_scsi[iSCSI tool], xref:installation-setup/requirements.adoc#_installing_cryptsetup_and_luks[cryptsetup], xref:installation-setup/requirements.adoc#_installing_device_mapper_userspace_tool[dmsetup]) exist for Longhorn
++
+* `NFSClientInstalled`: Checks if any of the following NFS clients are supported: `v4.2`, `v4.1`, or `v4.0`. NFS client is required for RWX volume and backup.
++
+* `KernelModulesLoaded`: Checks if the following Kernel modules are loaded:
++
+** `dm_crypt`: Required for the volume and backing image encryption.  
 
 Node conditions do not block the Longhorn deployment but they result in warnings in the Longhorn `Node` resource.
 For more information, see xref:installation-setup/requirements.adoc#_requirements[Longhorn Installation Requirements].

--- a/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
+++ b/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
@@ -202,3 +202,44 @@
 | State of this backup backing image: 0=New, 1=Pending, 2=InProgress, 3=Completed, 4=Error, 5=Unknown
 | longhorn_backup_backing_image_state{backup_backing_image="parrot"} 3
 |===
+
+## CSI
+
+The CSI sidecar component has built-in metrics for users to get insights into CSI operations. The CSI operations metrics cover total count, error count, and call latency. Longhorn enables the metrics by adding the flag `--http-endpoint` for each CSI sidecar component. You can use https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor[Prometheus's PodMonitor] to collect these metrics. 
+
+|===
+| Name | Port
+
+| longhorn-csi-attacher
+| 8000
+
+| longhorn-csi-provisioner
+| 8000
+
+| longhorn-csi-resizer
+| 8000
+
+| longhorn-csi-snapshotter
+| 8000
+|===
+
+The metrics provided by the CSI sidecar component are provided in a histogram format. For example, you can obtain metrics observing the time it takes to create a Longhorn Volume for the PVC.
+
+----
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="0.1"} 0
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="0.25"} 0
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="0.5"} 0
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="1"} 0
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="2.5"} 3
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="5"} 3
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="10"} 3
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="15"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="25"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="50"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="120"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="300"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="600"} 9
+csi_sidecar_operations_seconds_bucket{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume",le="+Inf"} 9
+csi_sidecar_operations_seconds_sum{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume"} 66.816478825
+csi_sidecar_operations_seconds_count{driver_name="driver.longhorn.io",grpc_status_code="OK",method_name="/csi.v1.Controller/ControllerPublishVolume"} 9
+----

--- a/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
+++ b/docs/version-1.8.0/modules/en/pages/observability/longhorn-metrics.adoc
@@ -45,6 +45,10 @@
 | longhorn_volume_write_latency
 | Write latency of this volume (ns)
 | longhorn_volume_write_latency{pvc_namespace="default",node="worker-2",pvc="testvol",volume="testvol"} 100000
+
+| longhorn_volume_file_system_read_only
+| This metric indicates that the volume is now in read-only mode. The metric is either 1 or no record for each volume
+| longhorn_volume_file_system_read_only{node="worker-2",pvc="testvol",pvc_namespace="default",volume="testvol"} 1
 |===
 
 == Node


### PR DESCRIPTION
Scope: v1.8.0
- [987](https://github.com/longhorn/website/pull/987/files): Default static StorageClass name
- [989](https://github.com/longhorn/website/pull/989/files): CSI metrics
- [990](https://github.com/longhorn/website/pull/990/files): Volume filesystem read-only metric
- [992](https://github.com/longhorn/website/pull/992/files): Recommended Kubernetes versions
- [993](https://github.com/longhorn/website/pull/993/files): Replica auto-balance best practices
- [994](https://github.com/longhorn/website/pull/994/files): Auto-salvage support for V2 volumes
- [995](https://github.com/longhorn/website/pull/995/files): KernelModulesLoaded node condition
- [996](https://github.com/longhorn/website/pull/996/files): Minimum supported Kubernetes version