### PR TITLE
[v1.8.0] Add content from community doc PRs (Oct 2024)

### DIFF
--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -186,11 +186,22 @@ To apply the storage network to existing RWX volumes, you must detach the volume
 
 For more information, see https://github.com/longhorn/longhorn/issues/8184[Issue #8184].
 
-## Operating Systems and Distributions
+== Operating Systems and Distributions
 
-### Talos Linux
+=== Talos Linux
 
 Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux clusters. To use V2 volumes, ensure that all nodes meet the V2 Data Engine prerequisites. For more information, see xref:installation-setup/os-distro/talos-linux.adoc#v2-data-engine[Talos Linux Support: V2 Data Engine].
+
+== Backup
+
+=== Related Custom Resources Might Disappear
+
+Longhorn attempts to clean up backup-related custom resources in the following scenarios:
+
+* A brief server downtime causes the NFS server to send an empty response.
+* A race condition occurs between related Longhorn backup controllers.
+
+The backup information is resynchronized during the next polling interval. For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].
 
 == V2 Data Engine
 

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -135,6 +135,10 @@ From this version, you need to add group id 6 to the security context or run con
 
 Starting with Longhorn v1.7.0, Longhorn supports Container-Optimized OS (COS), providing robust and efficient persistent storage solutions for Kubernetes clusters running on COS. For more information, see xref:installation-setup/os-distro/container-optimized-os.adoc[Container-Optimized OS (COS) Support].
 
+=== Upgrade Check Events
+
+Longhorn performs a pre-upgrade check whenever you upgrade using Helm or the Rancher App Marketplace. If a check fails, the upgrade stops and the reason for the check's failure is recorded. For more information, see xref:upgrades/longhorn-components/upgrade-longhorn-manager.adoc[Upgrading Longhorn Manager].
+
 == Resilience
 
 === RWX Volumes Fast Failover

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -194,14 +194,19 @@ Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux cl
 
 == Backup
 
-=== Related Custom Resources Might Disappear
+=== Backup Data On The Remote Backup Server Might Be Deleted
 
-Longhorn attempts to clean up backup-related custom resources in the following scenarios:
+In releases earlier than v1.8.0, Longhorn may unintentionally delete backup-related custom resources (such as `BackupVolume`, `BackupBackingImage`, `SystemBackup`, and `Backup`) and backup data on the remote backup server in the following scenarios:
 
 * A brief server downtime causes the NFS server to send an empty response.
-* A race condition occurs between related Longhorn backup controllers.
+* A race condition could delete the remote backup volume and its corresponding backups when the backup target is reset within a short period.
 
-The backup information is resynchronized during the next polling interval. For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].
+Starting with v1.8.0, Longhorn handles backup-related custom resources in the following manner:
+
+* If there are discrepancies between the backup information in the cluster and on the remote backup server, Longhorn deletes only the backup-related custom resources in the cluster.
+* The backup-related custom resources in the cluster may be deleted unintentionally while the remote backup data remains safely stored. The deleted resources are resynchronized from the remote backup server during the next polling period (if the backup target is available).
+
+For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].
 
 == V2 Data Engine
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/installation/helm-values.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/installation/helm-values.adoc
@@ -194,13 +194,13 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.openshift.oauthProxy.repository
 | string
-| `"longhornio/openshift-origin-oauth-proxy"`
-| Repository for the OAuth Proxy image. This setting applies only to OpenShift users.
+| `""`
+| Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users.
 
 | image.openshift.oauthProxy.tag
 | float
-| `4.14`
-| Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.14.
+| `""`
+| Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users.
 
 | image.pullPolicy
 | string

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
@@ -11,20 +11,51 @@ NOTE: OKD currently does not support the ARM platform. For more information, see
 
 Please refer to this section xref:installation-setup/installation/install-using-helm.adoc[Install with Helm] first.
 
-And then install {longhorn-product-name} with setting *_openshift.enabled_* true:
+Install Longhorn with the following settings:
+
+|===
+| Setting | Value | Example
+
+| `openshift.enabled`
+| `true`
+| N/A
+
+| `image.openshift.oauthProxy.repository`
+| Upstream image
+| `quay.io/openshift/origin-oauth-proxy`
+
+| `image.openshift.oauthProxy.tag`
+| Version 4.1 or later
+| `4.15`
+|===
 
 [subs="+attributes",bash]
 ----
-  helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace --set openshift.enabled=true
+helm install longhorn longhorn/longhorn \
+  --namespace longhorn-system \
+  --create-namespace \
+  --set openshift.enabled=true \
+  --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+  --set image.openshift.oauthProxy.tag=4.15
 ----
 
 === Install With `oc` Command
 
-You can install {longhorn-product-name} on https://www.okd.io/[OKD] clusters using the following command:
+Perform the following steps to install Longhorn on [OKD](https://www.okd.io/) clusters.
 
+. Download the `longhorn-okd.yaml` file.
++
+----
+wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-okd.yaml
+----
++
+. Specify the target `oauth-proxy` container image in the `longhorn-okd.yaml` file (for example, `quay.io/openshift/origin-oauth-proxy:4.15`).
++
+. Run the following command:
++
 [subs="+attributes",shell]
 ----
-    oc apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{current-version}/deploy/longhorn-okd.yaml
+oc apply -f longhorn-okd.yaml
 ----
 
 One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/settings.adoc
@@ -477,42 +477,39 @@ Enable improved ReadWriteMany volume HA by shortening the time it takes to recov
 
 === V2 Data Engine
 
-____
-Default: `false`
-____
+*Default*: `false`
 
 Setting that allows you to enable the V2 Data Engine, which is based on the Storage Performance Development Kit (SPDK). The V2 Data Engine is a preview feature and should not be used in production environments. For more information, see xref:longhorn-system/v2-data-engine/quick-start-guide.adoc[V2 Data Engine (Preview Feature)].
 
-____
-*Warning*
-
+[WARNING]
+====
 * DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached volumes.
 * When the V2 Data Engine is enabled, each instance-manager pod utilizes 1 CPU core. This high CPU usage is attributed to the spdk_tgt process running within each instance-manager pod. The spdk_tgt process is responsible for handling input/output (IO) operations and requires intensive polling. As a result, it consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations.
-____
+====
 
 === V2 Data Engine Hugepage Limit
 
-____
-Default: `2048`
-____
+*Default*: `2048`
 
 Maximum huge page size (in MiB) for the V2 Data Engine.
 
 === Guaranteed Instance Manager CPU for V2 Data Engine
 
-____
-Default: `1250`
-____
+*Default*: `1250`
 
-Number of millicpus on each node to be reserved for each instance manager pod when the V2 Data Engine is enabled. By default, the Storage Performance Development Kit (SPDK) target daemon within each instance manager pod uses 1 CPU core. Configuring a minimum CPU usage value is essential for maintaining engine and replica stability, especially during periods of high node workload.
+Number of millicpus on each node to be reserved for each instance manager pod when the V2 Data Engine is enabled. The Storage Performance Development Kit (SPDK) target daemon within each instance manager pod uses at least one CPU core. Configuring a minimum CPU usage value is essential for maintaining engine and replica stability, especially during periods of high node workload.
 
-[WARNING]
+[CAUTION]
 ====
-
-
 * Specifying a value of 0 disables CPU requests for instance manager pods. You must specify an integer between 1000 and 8000.
 * This is a global setting. Modifying the value triggers an automatic restart of the Instance Manager pods. However, V2 Instance Manager pods that use this setting are restarted only when no instances are running.
 ====
+
+=== V2 Data Engine CPU Mask
+
+*Default*: `0x1`
+
+CPU cores on which the Storage Performance Development Kit (SPDK) target daemon should run. The SPDK target daemon is located in each Instance Manager pod. Ensure that the number of cores is less than or equal to the guaranteed Instance Manager CPUs for the V2 Data Engine.
 
 == Snapshot
 

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.adoc
@@ -2,46 +2,44 @@
 :description: Enable CSI Snapshot Support for Programmatic Creation of SUSE® Storage Snapshots/Backups
 :current-version: {page-component-version}
 
-____
-*Prerequisite*
+== Prerequisites
 
 It is the responsibility of the Kubernetes distribution to deploy the snapshot controller as well as the related custom resource definitions.
 
 For more information, see https://kubernetes.io/docs/concepts/storage/volume-snapshots/[CSI Volume Snapshots].
-____
 
 == If your Kubernetes Distribution Does Not Bundle the Snapshot Controller
 
-You may manually install these components by executing the following steps.
+You may manually install these components.
 
-____
-*Prerequisite*
+=== Prerequisites
 
 Please install the same release version of snapshot CRDs and snapshot controller to ensure that the CRD version is compatible with the snapshot controller.
 
 For general use, update the snapshot controller YAMLs with an appropriate *namespace* prior to installing.
 
 For example, on a vanilla Kubernetes cluster, update the namespace from `default` to `kube-system` prior to issuing the `kubectl create` command.
-____
 
-Install the Snapshot CRDs:
+=== Install the Snapshot CRDs
 
-. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v7.0.2/client/config/crd
-because Longhorn v{current-version} uses https://kubernetes-csi.github.io/docs/external-snapshotter.html[CSI external-snapshotter] v7.0.2
+. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v8.1.0/client/config/crd
+because Longhorn v{current-version} uses https://kubernetes-csi.github.io/docs/external-snapshotter.html[CSI external-snapshotter] v8.1.0
 . Run `kubectl create -k client/config/crd`.
 . Do this once per cluster.
 
-Install the Common Snapshot Controller:
+=== Install the Common Snapshot Controller
 
-. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v7.0.2/deploy/kubernetes/snapshot-controller
-because Longhorn v{current-version} uses https://kubernetes-csi.github.io/docs/external-snapshotter.html[CSI external-snapshotter] v7.0.2
-. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
+. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v8.1.0/deploy/kubernetes/snapshot-controller because Longhorn v{current-version} uses https://kubernetes-csi.github.io/docs/external-snapshotter.html[CSI external-snapshotter] v8.1.0
+. Update the namespace to an appropriate value for your environment (for example, `kube-system`)
 . Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 . Do this once per cluster.
 +
-NOTE: previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
+[NOTE]
+====
+Previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 The updated YAML files are being deployed into `kube-system` namespace by default.
 Therefore, we suggest deleting the previous snapshot controller in the `default` namespace to avoid having multiple snapshot controllers.
+====
 
 See the https://github.com/kubernetes-csi/external-snapshotter#usage[Usage] section from the kubernetes
 external-snapshotter git repo for additional information.

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -9,6 +9,16 @@ For more information about how the backupstore works in Longhorn, see the xref:i
 
 If you don't have access to AWS S3 or want to give the backupstore a try first, we've also provided a way to <<_set_up_a_local_testing_backupstore,setup a local S3 testing backupstore>> using https://minio.io/[MinIO].
 
+[NOTE]
+====
+Longhorn attempts to clean up backup-related custom resources in the following scenarios:
+
+* A brief server downtime causes the NFS server to send an empty response.
+* A race condition occurs between related Longhorn backup controllers.
+
+The backup information is resynchronized during the next polling interval. For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].
+====
+
 Longhorn also supports setting up recurring snapshot/backup jobs for volumes, via Longhorn UI or Kubernetes Storage Class. See xref:snapshots-backups/volume-snapshots-backups/create-recurring-backup-snapshot-job.adoc[here] for details.
 
 [NOTE]

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/restore-volume-statefulset.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/restore-volume-statefulset.adoc
@@ -62,6 +62,36 @@ To restore, follow the below instructions. The example below uses a StatefulSet 
      volumeHandle: statefulset-vol-1 # must match volume name from Longhorn
    storageClassName: longhorn # must be same name that we will use later
 ----
++
+If you are using encrypted volumes, you must specify the `nodePublishSecretRef`, and `nodeStageSecretRef` when creating the `PersistentVolume`.
++
+[,yaml]
+----
+kind: PersistentVolume
+metadata:
+  name: statefulset-encrypted-vol-0
+spec:
+  capacity:
+    storage: <size>
+    volumeMode: Filesystem
+    accessModes:
+      - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Delete
+    csi:
+      driver: driver.longhorn.io
+      fsType: ext4
+      nodePublishSecretRef:
+        name: <secret-name>
+        namespace: <namespace>
+      nodeStageSecretRef:
+        name: <secret-name>
+        namespace: <namespace>
+      volumeAttributes:
+        numberOfReplicas: <replicas>
+        staleReplicaTimeout: "30"
+      volumeHandle: statefulset-encrypted-vol-0
+    storageClassName: longhorn
+----
 
 . In the `namespace` the `StatefulSet` will be deployed in, create PersistentVolume Claims *for each* `Persistent Volume`. The name of the `Persistent Volume Claim` must follow this naming scheme:
 +

--- a/docs/version-1.8.0/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
+++ b/docs/version-1.8.0/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
@@ -196,10 +196,18 @@ Besides, users might need to delete new components introduced by the new version
 
 To prevent any impact caused by failed upgrades from unsupported versions, Longhorn will automatically initiate a new job (`pre-upgrade`) to verify if the upgrade path is supported before upgrading when upgrading through `Helm` or `Rancher App Marketplace`.
 
-The `pre-upgrade` job will block the upgrade process and provide the failure reason in the logs of the pod.
-During the upgrade failure, the user's Longhorn system should remain intact without any impacts.
+The `pre-upgrade` job blocks the upgrade process and provides the cause of the failure in the pod logs.
 
-To recover, you need to run the below commands to rollback to the previously installed revision:
+Example:
+
+----
+2m33s     Normal      Created                   Pod/longhorn-pre-upgrade-v5tqq     Created container longhorn-pre-upgrade
+2m33s     Warning     FailedUpgradePreCheck     /longhorn-pre-upgrade              failed to upgrade since upgrading from v1.6.2 to v1.8.0 for minor version is not supported
+----
+
+During upgrade failure, the Longhorn system should remain intact without any impact.
+
+To recover, run the following commands to roll back to the previously installed revision:
 
 [subs="+attributes",shell]
 ----


### PR DESCRIPTION
Scope: v1.8.0
- [997](https://github.com/longhorn/website/pull/997/): Mirrored OpenShift image
- [999](https://github.com/longhorn/website/pull/999/): Backup-related custom resources
- [1000](https://github.com/longhorn/website/pull/1000/): PersistentVolume creation using encrypted volume
- [1001](https://github.com/longhorn/website/pull/1001/): External-snapshotter version
- [1002](https://github.com/longhorn/website/pull/1002/): V2 Data Engine CPU mask
- [1004](https://github.com/longhorn/website/pull/1004/): Potential remote backup data deletion 
- [1006](https://github.com/longhorn/website/pull/1006/): Pre-upgrade check events