### PR TITLE
[v1.8.0] Add content from community doc PRs (Nov to Dec 2024)

### DIFF
--- a/docs/version-1.7.0/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
+++ b/docs/version-1.7.0/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
@@ -52,7 +52,7 @@ On Kubernetes clusters managed by Rancher 2.1 or newer, the steps to upgrade the
 
 === Upgrade with Kubectl
 
-To upgrade with kubectl, run this command:
+Run the following command:
 
 ----
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{current-version}/deploy/longhorn.yaml
@@ -60,15 +60,15 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{current-v
 
 === Upgrade with Helm
 
-To upgrade with Helm, run this command:
+Run the following command:
 
 ----
 helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version {current-version}
 ----
 
-Upgrade with Helm Controller
+=== Upgrade with Helm Controller
 
-Update the value of `spec.version` in the `HelmChart` YAML file:
+Update the value of `spec.version` in the `HelmChart` YAML file.
 
 [,yaml]
 ----
@@ -79,29 +79,30 @@ spec:
   failurePolicy: abort
 ----
 
-Alternatively, if using the `spec.chartContent` key, create a patch file with
+Alternatively, if you are using the `spec.chartContent` key, create and apply a patch file.
 
+* Create the file:
 [,yaml]
 ----
 spec:
   chartContent: <base64 content> # tar cz of longhorn charts directory for release | base64 -w 0
 ----
 
-and then apply it with
-
+* Apply the file.
 ----
 kubectl  patch helmchart longhorn -n <namespace> --type merge --patch-file <name of patch file>
 ----
 
 [IMPORTANT]
 ====
-In both cases, ensure that `spec.failurePolicy` is set to "abort".  The only other value is the default: "reinstall", which performs an uninstall of Longhorn if the pre-upgrade check or the upgrade fails.  With "abort", it retries periodically, giving the user a chance to fix the problem.
+In both cases, ensure that `spec.failurePolicy` is set to `abort` so that Longhorn retries periodically, giving you a chance to fix issues. When `spec.failurePolicy` is set to the default value `reinstall`, Longhorn is uninstalled if either the pre-upgrade check or the upgrade itself fails.
 ====
 
 === Upgrade with Fleet
 
 Update the value of `helm.version` in the `fleet` YAML file of your GitOps repository.
 
+[,yaml]
 ----
 helm:
   repo: https://charts.longhorn.io
@@ -114,6 +115,7 @@ helm:
 
 Update the value of `spec.chart.spec.version` in the `HelmRelease` YAML file of your GitOps repository.
 
+[,yaml]
 ----
 spec:
   chart:
@@ -130,6 +132,7 @@ spec:
 
 Update the value of `targetRevision` in the `Application` YAML file of your GitOps repository.
 
+[,yaml]
 ----
 spec:
   project: default
@@ -139,8 +142,10 @@ spec:
       targetRevision: v{current-version} # Replace with the Longhorn version you'd like to upgrade to
 ----
 
-Then wait for all the pods to become running and Longhorn UI working. e.g.:
+Then wait for all the pods to become running and Longhorn UI working.
 
+Example:
+----
  $ kubectl -n longhorn-system get pod
  NAME                                                  READY   STATUS    RESTARTS      AGE
  engine-image-ei-4dbdb778-nw88l                        1/1     Running   0             4m29s
@@ -162,6 +167,7 @@ Then wait for all the pods to become running and Longhorn UI working. e.g.:
  csi-resizer-6d8cf5f99f-7vv89                          1/1     Running   1 (30s ago)   37s
  csi-provisioner-869bdc4b79-sn6zr                      1/1     Running   1 (30s ago)   43s
  longhorn-csi-plugin-b2zzj                             2/2     Running   0             24s
+----
 
 Next, xref:upgrades/longhorn-components/manually-upgrade-engine.adoc[upgrade Longhorn engine.]
 
@@ -173,7 +179,7 @@ If you attempt to upgrade from an unsupported version, the upgrade will fail. Wh
 
 === Upgrade with Kubectl
 
-When you upgrade with kubectl by running this command:
+Run the following command:
 
 [subs="+attributes",shell]
 ----

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -30,10 +30,6 @@ The functionality of the https://github.com/longhorn/longhorn/blob/master/script
 
 == General
 
-=== Supported Kubernetes Versions
-
-Ensure that Kubernetes v1.25 or later is running on your cluster before upgrading to Longhorn v{current-version}. v1.25 is the minimum version Longhorn v{current-version} supports.
-
 === Pod Security Policies Disabled & Pod Security Admission Introduction
 
 * Longhorn pods require privileged access to manage nodes' storage. In Longhorn `v1.3.x` or older, Longhorn was shipping some Pod Security Policies by default, (e.g., https://github.com/longhorn/longhorn/blob/4ba39a989b4b482d51fd4bc651f61f2b419428bd/chart/values.yaml#L260[link]).

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -202,7 +202,7 @@ Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux cl
 
 In releases earlier than v1.8.0, Longhorn may unintentionally delete backup-related custom resources (such as `BackupVolume`, `BackupBackingImage`, `SystemBackup`, and `Backup`) and backup data on the remote backup server in the following scenarios:
 
-* A brief server downtime causes the NFS server to send an empty response.
+* The NFS server becomes unavailable and sends an empty response.
 * A race condition could delete the remote backup volume and its corresponding backups when the backup target is reset within a short period.
 
 Starting with v1.8.0, Longhorn handles backup-related custom resources in the following manner:

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -139,6 +139,10 @@ Starting with Longhorn v1.7.0, Longhorn supports Container-Optimized OS (COS), p
 
 Longhorn performs a pre-upgrade check whenever you upgrade using Helm or the Rancher App Marketplace. If a check fails, the upgrade stops and the reason for the check's failure is recorded. For more information, see xref:upgrades/longhorn-components/upgrade-longhorn-manager.adoc[Upgrading Longhorn Manager].
 
+=== Install or Upgrade Using Helm Controller
+
+You can now install and upgrade Longhorn on clusters running RKE2 or K3s using the Helm Controller that is built into those distributions. The Helm Controller manages Helm charts using a HelmChart Custom Resource Definition (CRD), which contains most of the options that would normally be passed to the Helm command-line tool. For more information, see xref:installation-setup/installation/install-using-helm-controller.adoc[Install Using Helm Controller].
+
 == Resilience
 
 === RWX Volumes Fast Failover

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -212,6 +212,12 @@ Starting with v1.8.0, Longhorn handles backup-related custom resources in the fo
 
 For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].
 
+== System Backup And Restore
+
+=== Volume Backup Policy
+
+Starting with Longhorn v1.8.0, the `if-not-present` volume backup policy option ensures that the latest backup contains the most recent data. If the latest backup is outdated, Longhorn creates a new backup for the volume.
+
 == V2 Data Engine
 
 === Longhorn System Upgrade

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -139,6 +139,10 @@ Longhorn performs a pre-upgrade check whenever you upgrade using Helm or the Ran
 
 You can now install and upgrade Longhorn on clusters running RKE2 or K3s using the Helm Controller that is built into those distributions. The Helm Controller manages Helm charts using a HelmChart Custom Resource Definition (CRD), which contains most of the options that would normally be passed to the Helm command-line tool. For more information, see xref:installation-setup/installation/install-using-helm-controller.adoc[Install Using Helm Controller].
 
+=== Automatic Expansion of RWX Volumes
+
+Longhorn v1.8.0 supports fully automatic online expansion of RWX volumes. There is no need to scale down the workload or apply manual commands. For more information, see xref:volumes/volume-expansion.adoc#rwx-volume[RWX Volume].
+
 == Resilience
 
 === RWX Volumes Fast Failover
@@ -153,7 +157,7 @@ Starting with v1.7.0, Longhorn supports configuration of timeouts for replica re
 
 === Change in Engine Replica Timeout Behavior
 
-In versions earlier than v1.8.0, the xref:longhorn-system/settings.adoc#engine-replica-timeout[Engine Replica Timeout] setting was equally applied to all V1 volume replicas. In v1.8.0, a V1 engine marks the last active replica as failed only after twice the configured number of seconds (timeout value x 2) have passed.
+In versions earlier than v1.8.0, the xref:longhorn-system/settings.adoc#_engine_replica_timeout[Engine Replica Timeout] setting was equally applied to all V1 volume replicas. In v1.8.0, a V1 engine marks the last active replica as failed only after twice the configured number of seconds (timeout value x 2) have passed.
 
 == Data Integrity and Reliability
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
@@ -44,7 +44,7 @@ The following Linux OS distributions and versions have been verified during the 
 
 | 4.
 | Red Hat Enterprise Linux
-| 9.3
+| 9.5
 
 | 5.
 | Oracle Linux
@@ -52,15 +52,15 @@ The following Linux OS distributions and versions have been verified during the 
 
 | 6.
 | Rocky Linux
-| 9.3
+| 9.5
 
 | 7.
 | Talos Linux
-| 1.7
+| 1.8
 
 | 8.
 | Container-Optimized OS (GKE)
-| 113
+| 117
 |===
 
 {longhorn-product-name} relies heavily on kernel functionality and performs better on some kernel versions. The following activities,
@@ -109,17 +109,17 @@ We recommend running your Kubernetes cluster on one of the following versions. T
 |===
 | Release | Released | End-of-life
 
+| 1.31
+| 13 Aug 2024
+| 28 Oct 2025
+
 | 1.30
 | 17 Apr 2024
 | 28 Jun 2025
 
-| 1.28
-| 15 Aug 2023
-| 28 Oct 2024
-
-| 1.27
-| 11 Apr 2023
-| 28 Jun 2024
+| 1.29
+| 13 Dec 2023
+| 28 Feb 2025
 |===
 
 Referenced to https://endoflife.date/kubernetes.

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/best-practices.adoc
@@ -98,7 +98,9 @@ The list below contains known broken kernel versions that users should avoid usi
 | Related to this bug https://longhorn.io/kb/troubleshooting-rwx-volume-fails-to-attached-caused-by-protocol-not-supported/
 |===
 
-== Kubernetes Version
+== Kubernetes
+
+=== Kubernetes Version
 
 Ensure that your cluster is running Kubernetes v1.21 or later before upgrading {longhorn-product-name}.
 
@@ -121,6 +123,10 @@ We recommend running your Kubernetes cluster on one of the following versions. T
 |===
 
 Referenced to https://endoflife.date/kubernetes.
+
+=== CoreDNS Setup
+
+Ensure that CoreDNS runs with at least two replicas to maintain high availability. This setup minimizes interruptions in the DNS resolution when one CoreDNS pod experiences a temporary disruption.
 
 == Node and Disk Setup
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -1,7 +1,7 @@
 = Install {longhorn-product-name} Using Helm Controller
 :current-version: {page-component-version}
 
-You can install {longhorn-product-name} using the Helm chart controller built into RKE2 and K3s.
+You can install {longhorn-product-name} using the Helm Controller that is built into RKE2 and K3s.
 
 == Prerequisites
 
@@ -17,7 +17,7 @@ Use https://github.com/longhorn/longhorn/blob/v{current-version}/scripts/environ
 * For Kubernetes v1.25 or earlier, if your cluster still enables Pod Security Policy admission controller, set the helm value `enablePSP` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
 ====
 
-. Create a HelmChart yaml file similar to the following:
+. Create a HelmChart YAML file similar to the following:
 +
 [,yaml]
 ----
@@ -53,7 +53,7 @@ spec:
 For full details see the HelmChart controller docs:  https://docs.rke2.io/helm or https://docs.k3s.io/helm.
 ====
 +
-. Apply it to create the HelmChart CR and an installation job:
+. Apply the YAML to create the HelmChart CR and an installation job.
 +
 [,shell]
 ----
@@ -63,7 +63,7 @@ helmchart.helm.cattle.io/longhorn-install created
 +
 [NOTE]
 ====
-Deleting the helmchart CR will initiate uninstallation of {longhorn-product-name}.
+Deleting the HelmChart CR initiates uninstallation of {longhorn-product-name}.
 ====
 . Check the created resources.
 +

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/uninstallation.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/uninstallation.adoc
@@ -15,7 +15,7 @@ From Rancher UI, navigate to `Catalog Apps` tab and delete the {longhorn-product
 
 == Uninstalling {longhorn-product-name} using Helm
 
-Run this command:
+Run the following command:
 
 ----
 helm uninstall longhorn -n longhorn-system
@@ -23,7 +23,15 @@ helm uninstall longhorn -n longhorn-system
 
 == Uninstalling {longhorn-product-name} Using Helm Controller
 
-Run this command:
+Run the following command:
+
+----
+kubectl delete helmchart <HelmChart name> -n <HelmChart namespace>
+----
+
+== Uninstalling {longhorn-product-name} Using Helm Controller
+
+Run the following command:
 
 ----
 kubectl delete helmchart <HelmChart name> -n <HelmChart namespace>

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/customize-default-settings.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/customize-default-settings.adoc
@@ -166,6 +166,21 @@ spec:
     persistence.defaultClassReplicaCount: "2"
 ----
 
+=== Using Helm Controller
+
+In the HelmChart YAML file, add lines to `spec.set` with the desired settings:
+
+[,yaml]
+----
+spec:
+  ...
+  set:
+    defaultSettings.priorityClass: system-node-critical
+    defaultSettings.replicaAutoBalance: least-effort
+    defaultSettings.storageOverProvisioningPercentage: "200"
+    persistence.defaultClassReplicaCount: "2"
+----
+
 == Update Settings
 
 === Using the Longhorn UI

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
@@ -41,6 +41,7 @@ ____
      # custom max body size for file uploading like backing image uploading
      nginx.ingress.kubernetes.io/proxy-body-size: 10000m
  spec:
+   ingressClassName: nginx
    rules:
    - http:
        paths:

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/system-backups/create-system-backup.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/system-backups/create-system-backup.adoc
@@ -35,7 +35,7 @@ Here is an example of a cluster workload with a bare `Pod` workload. The system 
 
 You can create a Longhorn system backup using the Longhorn UI. Or with the `kubectl` command.
 
-=== Prerequisite
+=== Prerequisites
 
 * xref:snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc[]. Longhorn saves the system backups to the remote backup store. You will see an error during creation when the backup target is unset.
 +
@@ -49,11 +49,11 @@ NOTE: Longhorn system restores volume with the latest backup. We recommend updat
 
 ==== Volume Backup Policy
 
-The Longhorn system backup offers the following volume backup policies:
+The Longhorn system backup offers the following volume backup policy options:
 
-* `if-not-present`: Longhorn will create a backup for volumes that currently lack a backup.
-* `always`: Longhorn will create a backup for all volumes, regardless of their existing backups.
-* `disabled`: Longhorn will not create any backups for volumes.
+* `if-not-present`: Longhorn creates a backup for volumes that either lack an existing backup or have an outdated latest backup.
+* `always`: Longhorn creates a backup for all volumes, regardless of their existing backups.
+* `disabled`: Longhorn does not create any backups for volumes.
 
 === Using Longhorn UI
 

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -11,9 +11,11 @@ If you don't have access to AWS S3 or want to give the backupstore a try first, 
 
 [NOTE]
 ====
-Longhorn attempts to clean up backup-related custom resources in the following scenarios:
+* The lifecycle of Longhorn backups within the backupstore is managed entirely by Longhorn. *Applying retention policies directly on the backupstore is strictly prohibited*.
 
-* A brief server downtime causes the NFS server to send an empty response.
+* Longhorn attempts to clean up backup-related custom resources in the following scenarios:
+
+* The NFS server becomes unavailable and sends an empty response.
 * A race condition occurs between related Longhorn backup controllers.
 
 The backup information is resynchronized during the next polling interval. For more information, see https://github.com/longhorn/longhorn/issues/9530[Issue #9530].

--- a/docs/version-1.8.0/modules/en/pages/volumes/volume-expansion.adoc
+++ b/docs/version-1.8.0/modules/en/pages/volumes/volume-expansion.adoc
@@ -129,26 +129,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 [discrete]
 ==== RWX volume
 
-Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
+Starting with v1.8.0, Longhorn supports fully automatic online expansion of the filesystem (NFS) for RWX volumes. This feature requires that the v1.8.0 versions of the following components are running:
 
-[discrete]
-===== Online
+- Longhorn Manager
+- CSI plugin
+- Share Manager (manages the NFS export)
 
-. Expand the block device of the RWX volume via PVC or UI.
-. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
-+
-[subs="+attributes",shell]
+[NOTE]
+====
+During upgrades, the Share Manager pods (one for each RWX volume) are not upgraded automatically to avoid disruptions.
+====
+
+After growing the block device, the CSI layer sends a resize command to the Share Manager to grow the filesystem within the block device.  With a down-rev share-manager, the command fails with an "unimplemented" error code and so no expansion happens. To obtain the right image before the expansion, force a restart of the pod. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`) and delete it.
+
+[,shell]
 ----
- kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
+kubectl -n longhorn-system delete pod <the share manager pod>
 ----
 
-____
-*Important*: +
-Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
-____
+The pod is automatically recreated using the appropriate version, and the expansion is completed. Further expansions will not require any further intervention.
 
 [discrete]
 ===== Offline
+
+Perform the following steps to allow expansion of RWX volumes while offline.
 
 . Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
 . After the scale command returns, run the following command and verify that the state is `detached`.
@@ -161,4 +165,4 @@ ____
 . Expand the block device using either the PVC or the Longhorn UI.
 . Scale up the workload.
 
-The reattached volume will have the expanded size.
+The reattached volume will have the expanded size. Furthermore, the Share Manager pod will be recreated with the current version.


### PR DESCRIPTION
Scope: v1.8.0
- [1007](https://github.com/longhorn/website/pull/1007): Helm Controller
- [1008](https://github.com/longhorn/website/pull/1008): Supported Kubernetes versions
- [1009](https://github.com/longhorn/website/pull/1009): Volume backup policy
- [1010](https://github.com/longhorn/website/pull/1010): Prohibited retention policy
- [1011](https://github.com/longhorn/website/pull/1011): CoreDNS setup best practice
- [1012](https://github.com/longhorn/website/pull/1012): Automatic RWX volume expansion
- [1013](https://github.com/longhorn/website/pull/1013): Missing ingressClassName
- [1014](https://github.com/longhorn/website/pull/1014): OS and Kubernetes versions