### PR TITLE
[v1.8.0] Add content from community doc PRs (Dec 2024)

### DIFF
--- a/docs/version-1.8.0/modules/en/pages/high-availability/data-locality.adoc
+++ b/docs/version-1.8.0/modules/en/pages/high-availability/data-locality.adoc
@@ -15,7 +15,7 @@ Longhorn currently supports two modes for data locality settings:
 
 * `disabled`: This is the default option. There may or may not be a replica on the same node as the attached volume (workload).
 * `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
-* `strict-local`: This option enforces Longhorn keep the *only one replica* on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+* `strict-local`: This option enforces Longhorn keep the *only one replica* on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with xref:../volumes/rwx-volumes.adoc[ReadWriteMany (RWX) volumes].
 
 == How to Set Data Locality For Volumes
 

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -15,6 +15,14 @@ The functionality of the https://github.com/longhorn/longhorn/blob/master/script
 
 Longhorn performs a pre-upgrade check whenever you upgrade using Helm or the Rancher App Marketplace. If a check fails, the upgrade stops and the reason for the check's failure is recorded. For more information, see xref:upgrades/longhorn-components/upgrade-longhorn-manager.adoc[Upgrading Longhorn Manager].
 
+== Manual Checks Before Upgrades
+
+Automated checks are only performed on some upgrade paths, and the pre-upgrade checker may not cover some scenarios. Manual checks, performed using either kubectl or the UI, are recommended for these schenarios. You can take mitigating actions or defer the upgrade until issues are addressed.
+
+* Ensure that all V2 Data Engine volumes are detached and the replicas are stopped. The V2 Data Engine currently does not support live upgrades.
+* Avoid upgrading when volumes are in the "Faulted" status. If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
+* Avoid upgrading if a failed BackingImage exists. For more information, see xref:volumes/backing-images/backing-images.adoc[Backing Image].
+
 === Install or Upgrade Using Helm Controller
 
 You can now install and upgrade Longhorn on clusters running RKE2 or K3s using the Helm Controller that is built into those distributions. The Helm Controller manages Helm charts using a HelmChart Custom Resource Definition (CRD), which contains most of the options that would normally be passed to the Helm command-line tool. For more information, see xref:installation-setup/installation/install-using-helm-controller.adoc[Install Using Helm Controller].

--- a/docs/version-1.8.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.8.0/modules/en/pages/important-notes.adoc
@@ -1,135 +1,15 @@
-= Important Notes for v1.7.0
+= Important Notes for v1.8.0
 :current-version: {page-component-version}
 
-Please see https://github.com/longhorn/longhorn/releases/tag/v{current-version}[here] for the full release note.
-
-== Warning
-
-=== Unable to Attach Volumes Created Before v1.5.2 and v1.4.4
-
-The Longhorn team has identified https://github.com/longhorn/longhorn/issues/9267[a critical issue] that affects volume attachment in Longhorn v1.7.0. A fix for this issue will be included in v1.7.1, which is in active development.
-
-Avoid upgrading to v1.7.0 if your Longhorn cluster contains `engine` resources with the following characteristics:
-
-* Resource name: The format is `<volume name>-e-<8-char random id>`.
-* Time of creation: A Longhorn version earlier than v1.5.2 and v1.4.4 was installed on the cluster.
-
-Run the following command to check if you can safely upgrade your Longhorn cluster to v1.7.0:
-
-____
-----
-[ $(kubectl -n longhorn-system get engines.longhorn.io -o name | grep -E '\-e\-[a-z0-9]{8}$' | wc -l) -gt 0 ] && echo "Please hold off on upgrading to v1.7.0 until v1.7.1 is available." || echo "Safe to upgrade to v1.7.0."
-----
-____
+Please see https://github.com/longhorn/longhorn/releases/tag/v{current-version}[here] for the full release notes.
 
 == Deprecation
 
 === Environment Check Script
 
-The functionality of the https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh[environment check script] (`environment_check.sh`) overlaps with that of the Longhorn CLI, which is available starting with v1.7.0. Because of this, the script is deprecated in v1.7.0 and is scheduled for removal in v1.8.0.
+The functionality of the https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh[environment check script] (`environment_check.sh`) overlaps with that of the Longhorn CLI, which is available starting with v1.7.0. Because of this, the script is deprecated in v1.7.0 and is scheduled for removal in v1.9.0.
 
 == General
-
-=== Pod Security Policies Disabled & Pod Security Admission Introduction
-
-* Longhorn pods require privileged access to manage nodes' storage. In Longhorn `v1.3.x` or older, Longhorn was shipping some Pod Security Policies by default, (e.g., https://github.com/longhorn/longhorn/blob/4ba39a989b4b482d51fd4bc651f61f2b419428bd/chart/values.yaml#L260[link]).
-However, Pod Security Policy has been deprecated since Kubernetes v1.21 and removed since Kubernetes v1.25, https://kubernetes.io/docs/concepts/security/pod-security-policy/[link].
-Therefore, we stopped shipping the Pod Security Policies by default.
-For Kubernetes < v1.25, if your cluster still enables Pod Security Policy admission controller, please do:
- ** Helm installation method: set the helm value `enablePSP` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
- ** Kubectl installation method: need to apply the https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/podsecuritypolicy.yaml[podsecuritypolicy.yaml] manifest in addition to applying the `longhorn.yaml` manifests.
- ** Rancher UI installation method: set `Other Settings > Pod Security Policy` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
-* As a replacement for Pod Security Policy, Kubernetes provides a new mechanism, https://kubernetes.io/docs/concepts/security/pod-security-admission/[Pod Security Admission].
-If you enable the Pod Security Admission controller and change the default behavior to block privileged pods,
-you must add the correct labels to the namespace where Longhorn pods run to allow Longhorn pods to start successfully
-(because Longhorn pods require privileged access to manage storage).
-For example, adding the following labels to the namespace that is running Longhorn pods:
-  `yaml
-  apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: longhorn-system
-    labels:
-      pod-security.kubernetes.io/enforce: privileged
-      pod-security.kubernetes.io/enforce-version: latest
-      pod-security.kubernetes.io/audit: privileged
-      pod-security.kubernetes.io/audit-version: latest
-      pod-security.kubernetes.io/warn: privileged
-      pod-security.kubernetes.io/warn-version: latest
- 	`
-
-=== Command Line Tool
-
-The Longhorn CLI (binary name: `longhornctl`), which is the official Longhorn command line tool, was introduced in v1.7.0. This tool interacts with Longhorn by creating Kubernetes custom resources (CRs) and executing commands inside a dedicated pod for in-cluster and host operations. Usage scenarios include installation, operations such as exporting replicas, and troubleshooting. For more information, see xref:longhorn-system/system-access/longhorn-cli.adoc[Command Line Tool (longhornctl)].
-
-=== Minimum XFS Filesystem Size
-
-Recent versions of `xfsprogs` (including the version Longhorn currently uses) _do not allow_ the creation of XFS
-filesystems https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=6e0ed3d19c54603f0f7d628ea04b550151d8a262[smaller than 300
-MiB].
-Longhorn v{current-version} does not allow the following:
-
-* CSI flow: Volume provisioning if `resources.requests.storage < 300 Mi` and the corresponding StorageClass has `fsType:
-xfs`
-* Longhorn UI: `Create PV/PVC` with `File System: XFS` action to be completed on a volume that has `spec.size < 300 Mi`
-
-However, Longhorn still allows the listed actions when cloning or restoring volumes created with earlier Longhorn
-versions.
-
-=== Longhorn PVC with Block Volume Mode
-
-Starting with v1.6.0, Longhorn is changing the default group ID of Longhorn devices from `0` (root group) to `6` (typically associated with the "disk" group).
-This change allows non-root containers to read or write to PVs using the *Block* volume mode. Note that Longhorn still keeps the owner of the Longhorn block devices as root.
-As a result, if your pod has security context such that it runs as non-root user and is part of the group id 0, the pod will no longer be able to read or write to Longhorn block volume mode PVC anymore.
-This use case should be very rare because running as a non-root user with the root group does not make much sense.
-More specifically, this example will not work anymore:
-
-[subs="+attributes",yaml]
-----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: longhorn-block-vol
-spec:
-  accessModes:
-    - ReadWriteOnce
-  volumeMode: Block
-  storageClassName: longhorn
-  resources:
-    requests:
-      storage: 2Gi
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: block-volume-test
-  namespace: default
-spec:
-  securityContext:
-    runAsGroup: 1000
-    runAsNonRoot: true
-    runAsUser: 1000
-    supplementalGroups:
-    - 0
-  containers:
-    - name: block-volume-test
-      image: ubuntu:20.04
-      command: ["sleep", "360000"]
-      imagePullPolicy: IfNotPresent
-      volumeDevices:
-        - devicePath: /dev/longhorn/testblk
-          name: block-vol
-  volumes:
-    - name: block-vol
-      persistentVolumeClaim:
-        claimName: longhorn-block-vol
-----
-
-From this version, you need to add group id 6 to the security context or run container as root. For more information, see xref:volumes/pvc-ownership-and-permission.adoc[Longhorn PVC ownership and permission]
-
-=== Container-Optimized OS Support
-
-Starting with Longhorn v1.7.0, Longhorn supports Container-Optimized OS (COS), providing robust and efficient persistent storage solutions for Kubernetes clusters running on COS. For more information, see xref:installation-setup/os-distro/container-optimized-os.adoc[Container-Optimized OS (COS) Support].
 
 === Upgrade Check Events
 
@@ -141,15 +21,9 @@ You can now install and upgrade Longhorn on clusters running RKE2 or K3s using t
 
 === Automatic Expansion of RWX Volumes
 
-Longhorn v1.8.0 supports fully automatic online expansion of RWX volumes. There is no need to scale down the workload or apply manual commands. For more information, see xref:volumes/volume-expansion.adoc#rwx-volume[RWX Volume].
+Longhorn v1.8.0 supports fully automatic online expansion of RWX volumes. There is no need to scale down the workload or apply manual commands. For more information, see xref:volumes/volume-expansion.adoc#_rwx_volume[RWX Volume].
 
 == Resilience
-
-=== RWX Volumes Fast Failover
-
-RWX Volumes fast failover is introduced in Longhorn v1.7.0 to improve resilience to share-manager pod failures. This failover mechanism quickly detects and responds to share-manager pod failures independently of the Kubernetes node failure sequence and timing. For details, see xref:high-availability/rwx-volume-fast-failover.adoc[RWX Volume Fast Failover].
-
-NOTE: In rare circumstances, it is possible for the failover to become deadlocked. This happens if the NFS server pod creation is blocked by a recovery action that is itself blocked by the failover-in-process state.  If the feature is enabled, and a failover takes more than a minute or two, it is probably stuck in this situation.  There is an explanation and a workaround in xref:high-availability/rwx-volume-fast-failover.adoc[RWX Volume Fast Failover].
 
 === Timeout Configuration for Replica Rebuilding and Snapshot Cloning
 
@@ -159,46 +33,11 @@ Starting with v1.7.0, Longhorn supports configuration of timeouts for replica re
 
 In versions earlier than v1.8.0, the xref:longhorn-system/settings.adoc#_engine_replica_timeout[Engine Replica Timeout] setting was equally applied to all V1 volume replicas. In v1.8.0, a V1 engine marks the last active replica as failed only after twice the configured number of seconds (timeout value x 2) have passed.
 
-== Data Integrity and Reliability
-
-=== Support Periodic and On-Demand Full Backups to Enhance Backup Reliability
-
-Since Longhorn v1.7.0, periodic and on-demand full backups have been supported to enhance backup reliability. Prior to v1.7.0, the initial backup was a full backup, with subsequent backups being incremental. If any block became corrupted, all backup revisions relying on that block would also be corrupted. To address this issue, Longhorn now supports performing a full backup after every N incremental backups, as well as on-demand full backups. This approach decreases the likelihood of backup corruption and enhances the overall reliability of the backup process. For more information, see xref:snapshots-backups/volume-snapshots-backups/create-recurring-backup-snapshot-job.adoc[Recurring Snapshots and Backups] and xref:snapshots-backups/volume-snapshots-backups/create-backup.adoc[Create a Backup].
-
-=== High Availability of Backing Images
-
-To address the single point of failure (SPOF) issue with backing images, high availability for backing images was introduced in Longhorn v1.7.0. For more information, please see xref:volumes/backing-images/backing-images.adoc#_number_of_copies[Backing Image].
-
-== Scheduling
-
-=== Auto-Balance Pressured Disks
-
-The replica auto-balancing feature was enhanced in Longhorn v1.7.0 to address disk space pressure from growing volumes. A new setting, called `replica-auto-balance-disk-pressure-percentage`, allows you to set a threshold for automatic actions. The enhancements reduce the need for manual intervention by automatically rebalancing replicas during disk pressure, and improve performance by enabling faster replica rebuilding using local file copying. For more information, see xref:longhorn-system/settings.adoc#replica-auto-balance-disk-pressure-threshold-[`replica-auto-balance-disk-pressure-percentage`] and https://github.com/longhorn/longhorn/issues/4105[Issue #_4_1_0_5].
-
-== Networking
-
-=== Storage Network Support for Read-Write-Many (RWX) Volumes
-
-Starting with Longhorn v1.7.0, the xref:longhorn-system/networking/storage-network.adoc[storage network] supports RWX volumes. However, the network's reliance on Multus results in a significant restriction.
-
-Multus networks operate within the Kubernetes network namespace, so Longhorn can mount NFS endpoints only within the CSI plugin pod container network namespace. Consequently, NFS mount connections to the Share Manager pod become unresponsive when the CSI plugin pod restarts. This occurs because the namespace in which the connection was established is no longer available.
-
-Longhorn circumvents this restriction by providing the following settings:
-
-* xref:longhorn-system/settings.adoc#_storage_network_for_rwx_volume_enabled[Storage Network For RWX Volume Enabled]: When this setting is disabled, the storage network applies only to RWO volumes. The NFS client for RWX volumes is mounted over the cluster network in the host network namespace. This means that restarting the CSI plugin pod does not affect the NFS mount connections
-* xref:longhorn-system/settings.adoc#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly]: When the RWX volumes are created over the storage network, this setting actively deletes RWX volume workload pods when the CSI plugin pod restarts. This allows the pods to be remounted and prevents dangling mount entries.
-
-You can upgrade clusters with pre-existing RWX volume workloads to Longhorn v1.7.0. During and after the upgrade, the workload pod must not be interrupted because the NFS share connection uses the cluster IP, which remains valid in the host network namespace.
-
-To apply the storage network to existing RWX volumes, you must detach the volumes, enable the xref:longhorn-system/settings.adoc#_storage_network_for_rwx_volume_enabled[Storage Network For RWX Volume Enabled] setting, and then reattach the volumes.
-
-For more information, see https://github.com/longhorn/longhorn/issues/8184[Issue #8184].
-
 == Operating Systems and Distributions
 
 === Talos Linux
 
-Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux clusters. To use V2 volumes, ensure that all nodes meet the V2 Data Engine prerequisites. For more information, see xref:installation-setup/os-distro/talos-linux.adoc#v2-data-engine[Talos Linux Support: V2 Data Engine].
+Longhorn v1.8.0 and later versions support usage of V2 volumes in Talos Linux clusters. To use V2 volumes, ensure that all nodes meet the V2 Data Engine prerequisites. For more information, see xref:installation-setup/os-distro/talos-linux.adoc#_v2_data_engine[Talos Linux Support: V2 Data Engine].
 
 == Backup
 
@@ -227,36 +66,6 @@ Starting with Longhorn v1.8.0, the `if-not-present` volume backup policy option 
 === Longhorn System Upgrade
 
 Longhorn currently does not support live upgrading of V2 volumes. Ensure that all V2 volumes are detached before initiating the upgrade process.
-
-=== Enable Both `vfio_pci` and `uio_pci_generic` Kernel Modules
-
-According to the https://spdk.io/doc/system_configuration.html[SPDK System Configuration User Guide], neither `vfio_pci` nor `uio_pci_generic` is universally suitable for all devices and environments. Therefore, users can enable both `vfio_pci` and `uio_pci_generic` kernel modules. This allows Longhorn to automatically select the appropriate module. For more information, see this https://github.com/longhorn/longhorn/issues/9182[link].
-
-=== Online Replica Rebuilding
-
-Online replica rebuilding was introduced in Longhorn 1.7.0, so offline replica rebuilding has been removed.
-
-=== Block-type Disk Supports SPDK AIO, NVMe and VirtIO Bdev Drivers
-
-Before Longhorn v1.7.0, Longhorn block-type disks only supported the SPDK AIO bdev driver, which introduced extra performance penalties. Since v1.7.0, block devices can be directly managed by SPDK NVMe or VirtIO bdev drivers, improving IO performance through a kernel bypass scheme. For more information, see this https://github.com/longhorn/longhorn/issues/7672[link].
-
-=== Filesystem Trim
-
-Filesystem trim is supported since Longhorn v1.7.0. If a disk is managed by the SPDK AIO bdev driver, the Trim (UNMAP) operation is not recommended in a production environment (ref). It is recommended to manage a block-type disk with an NVMe bdev driver.
-
-Starting with Longhorn v1.8.0, filesystem trim is blocked when the target V2 volume is in a degraded state. This ensures the reliability of the volume head size during the auto-salvage operation.
-
-=== Linux Kernel on Longhorn Nodes
-
-Host machines with Linux kernel 5.15 may unexpectedly reboot when volume-related IO errors occur. To prevent this, update the Linux kernel on Longhorn nodes to version 5.19 or later. For more information, see xref:longhorn-system/v2-data-engine/prerequisites.adoc[Prerequisites]. Version 6.7 or later is recommended for improved system stability.
-
-=== Snapshot Creation Time As Shown in the UI Occasionally Changes
-
-Snapshots created before Longhorn v1.7.0 may change occasionally. This issue arises because the engine randomly selects a replica and its snapshot map each time the UI requests snapshot information or when a replica is rebuilt with a random healthy replica. This can lead to potential time gaps between snapshots among different replicas. Although this bug was fixed in v1.7.0, snapshots created before this version may still encounter the issue. For more information, see this https://github.com/longhorn/longhorn/issues/7641[link].
-
-=== Unable To Revert a Volume to a Snapshot Created Before Longhorn v1.7.0
-
-Reverting a volume to a snapshot created before Longhorn v1.7.0 is not supported due to an incorrect UserCreated flag set on the snapshot. The workaround is to back up the existing snapshots before upgrading to Longhorn v1.7.0 and restore them if needed. The bug is fixed in v1.7.0, and more information can be found https://github.com/longhorn/longhorn/issues/9054[here].
 
 === Disaster Recovery Volumes
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/container-optimized-os.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/container-optimized-os.adoc
@@ -85,7 +85,8 @@ NOTE: The agent installs the iSCSI daemon (iscsid) in a container using a packag
 
 == Limitations
 
-In COS clusters, {longhorn-product-name} currently supports only V1 data volumes.
+* {longhorn-product-name} currently supports only V1 data volumes in COS clusters.
+* You can use `pbkdf2` for volume encryption if the built-in `cryptsetup` utility in your COS cluster does not support `argon2i` or `argon2id`. For more information, see https://github.com/longhorn/longhorn/issues/10049[Issue #10049].
 
 == References
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -29,9 +29,7 @@ For detailed instructions, see the Talos documentation on https://www.talos.dev/
 
 {longhorn-product-name} requires pod security `enforce: "privileged"`.
 
-By default, Talos Linux applies a `baseline` pod security profile across namespaces, except for the kube-system namespace. This default setting restricts {longhorn-product-name}'s ability to manage and access system resources. For more information, see xref:installation-setup/requirements.adoc#_root_and_privileged_permission[Root and Privileged Permission].
-
-For detailed instructions, see xref:important-notes.adoc#_pod_security_policies_disabled__pod_security_admission_introduction[Pod Security Policies Disabled & Pod Security Admission Introduction] and the Talos documentation on https://www.talos.dev/v1.6/kubernetes-guides/configuration/pod-security/[Pod Security].
+By default, Talos Linux applies a `baseline` pod security profile across namespaces, except for the kube-system namespace. This default setting restricts {longhorn-product-name}'s ability to manage and access system resources. For more information, see xref:installation-setup/requirements.adoc#_root_and_privileged_permission[Root and Privileged Permission] and the Talos documentation on https://www.talos.dev/v1.6/kubernetes-guides/configuration/pod-security/[Pod Security].
 
 === Data Path Mounts
 

--- a/docs/version-1.8.0/modules/en/pages/installation-setup/requirements.adoc
+++ b/docs/version-1.8.0/modules/en/pages/installation-setup/requirements.adoc
@@ -147,6 +147,7 @@ If MountPropagation is disabled, Base Image feature will be disabled.
 Below are the directories {longhorn-product-name} components requiring access with root and privileged permissions :
 
 * Longhorn Manager
+ ** /boot: Get information about required modules from `/boot/config-$(uname -r)` on the host.
  ** /dev: Block devices created by Longhorn are under the `/dev` path.
  ** /proc: Find the recognized host process like container runtime, then use `nsenter` to access the mounts on the host to understand disks usage.
  ** /var/lib/longhorn: The default path for storing volume data on a host.

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/networking/storage-network.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/networking/storage-network.adoc
@@ -59,8 +59,6 @@ Configure the setting xref:longhorn-system/settings.adoc#_storage_network_for_rw
 
 When an RWX volume is created with the storage network, the NFS mount point connection must be re-established when the CSI plugin pod restarts. Longhorn provides the xref:longhorn-system/settings.adoc#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly] setting, which automatically deletes RWX volume workload pods when the CSI plugin pod restarts. However, the workload pod's NFS mount point could become unresponsive when the setting is disabled or the pod is not managed by a controller. In such cases, you must manually restart the CSI plugin pod.
 
-For more information, see xref:important-notes.adoc#_storage_network_support_for_read_write_many_rwx_volumes[Storage Network Support for Read-Write-Many (RWX) Volume] in Important Notes.
-
 == History
 
 * https://github.com/longhorn/longhorn/issues/2285[Original Feature Request (since v1.3.0)]

--- a/docs/version-1.8.0/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
+++ b/docs/version-1.8.0/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
@@ -11,7 +11,7 @@
 ARCH="amd64"
 
 # Download the release binary.
-curl -LO "https://github.com/longhorn/cli/releases/download/{current-version}/longhornctl-linux-$\{ARCH}"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
 ----
 
 . Validate the binary:
@@ -19,7 +19,7 @@ curl -LO "https://github.com/longhorn/cli/releases/download/{current-version}/lo
 [subs="+attributes",bash]
 ----
 # Download the checksum for your architecture.
-curl -LO "https://github.com/longhorn/cli/releases/download/{current-version}/longhornctl-linux-$\{ARCH}.sha256"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
 
 # Verify the downloaded binary matches the checksum.
 echo "$(cat longhornctl-linux-$\{ARCH}.sha256 | awk '{print $1}') longhornctl-linux-$\{ARCH}" | sha256sum --check

--- a/docs/version-1.8.0/modules/en/pages/nodes/node-conditions.adoc
+++ b/docs/version-1.8.0/modules/en/pages/nodes/node-conditions.adoc
@@ -19,6 +19,10 @@ Node conditions:
 * `KernelModulesLoaded`: Checks if the following Kernel modules are loaded:
 +
 ** `dm_crypt`: Required for the volume and backing image encryption.  
++
+* `HugePagesAvailable`: Indicates whether the node is properly configured with HugePages (2Mi) as required by the Longhorn V2 Data Engine. This includes verifying the following:
++
+** HugePages (2Mi) are registered as a Kubernetes resource (`hugepages-2Mi`).
+** The configured HugePages capacity meets or exceeds the value defined in the `v2-data-engine-hugepage-limit` setting.
 
-Node conditions do not block the Longhorn deployment but they result in warnings in the Longhorn `Node` resource.
-For more information, see xref:installation-setup/requirements.adoc#_requirements[Longhorn Installation Requirements].
+Node conditions do not block the Longhorn deployment but they result in warnings in the Longhorn `Node` resource. For more information, see xref:installation-setup/requirements.adoc#_requirements[Longhorn Installation Requirements].

--- a/docs/version-1.8.0/modules/en/pages/upgrades/upgrades.adoc
+++ b/docs/version-1.8.0/modules/en/pages/upgrades/upgrades.adoc
@@ -55,6 +55,14 @@ The following table outlines the supported upgrade paths.
 Longhorn only allows upgrades from patch versions of the last minor release before the new major version. For example, if v1.8.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.8.0 to any patch version of v2.0.
 ====
 
+== Manual Checks Before Upgrades
+
+Automated checks are only performed on some upgrade paths, and the pre-upgrade checker may not cover some scenarios. Manual checks, performed using either kubectl or the UI, are recommended for these schenarios. You can take mitigating actions or defer the upgrade until issues are addressed.
+
+* Ensure that all V2 Data Engine volumes are detached and the replicas are stopped. The V2 Data Engine currently does not support live upgrades.
+* Avoid upgrading when volumes are in the "Faulted" status. If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
+* Avoid upgrading if a failed BackingImage exists. For more information, see xref:../volumes/backing-images/backing-images.adoc[Backing Image].
+
 == Upgrading Longhorn
 
 There are normally two steps in the upgrade process: first upgrade Longhorn manager to the latest version, then manually upgrade the Longhorn engine to the latest version using the latest Longhorn manager.

--- a/docs/version-1.8.0/modules/en/pages/volumes/volume-encryption.adoc
+++ b/docs/version-1.8.0/modules/en/pages/volumes/volume-encryption.adoc
@@ -67,6 +67,8 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
   csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
   csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-expand-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/node-expand-secret-namespace: "longhorn-system"
 ----
 
 * Example of a StorageClass with a volume-specific Secret:
@@ -91,6 +93,8 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
   csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
   csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/node-expand-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-expand-secret-namespace: ${pvc.namespace}
 ----
 
 == Using an Encrypted Volume
@@ -102,7 +106,12 @@ A newly-created PVC remains in the `Pending` state until the associated Secret i
 
 == Filesystem Expansion
 
-Longhorn supports xref:volumes/volume-expansion.adoc#_encrypted_volume[offline expansion] for encrypted volumes.
+Longhorn supports xref:volumes/volume-expansion.adoc#_encrypted_volume[both online and offline expansion] for encrypted volumes.
+
+The following StorageClass parameters are required to enable online expansion:
+
+* `csi.storage.k8s.io/node-expand-secret-name`
+* `csi.storage.k8s.io/node-expand-secret-namespace`
 
 == History
 

--- a/docs/version-1.8.0/modules/en/pages/volumes/volume-expansion.adoc
+++ b/docs/version-1.8.0/modules/en/pages/volumes/volume-expansion.adoc
@@ -118,7 +118,15 @@ Follow the steps below to resize the filesystem:
 [discrete]
 ==== Encrypted volume
 
-Due to https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/[the upstream limitation], Longhorn cannot handle *online* expansion for encrypted volumes automatically unless you enable the feature gate `CSINodeExpandSecret`.
+Longhorn support for online expansion depends on Kubernetes.
+
+* Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
+* In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+
+You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+
+* `csi.storage.k8s.io/node-expand-secret-name`
+* `csi.storage.k8s.io/node-expand-secret-namespace`
 
 If you cannot enable it but still prefer to do online expansion, you can:
 


### PR DESCRIPTION
Scope: v1.8.0
- [1017](https://github.com/longhorn/website/pull/1017): Host boot directory
- [1018](https://github.com/longhorn/website/pull/1018): CLI installation cURL commands
- [1021](https://github.com/longhorn/website/pull/1021): Outdated important notes
- [1022](https://github.com/longhorn/website/pull/1022): Data locality (strict-local) limitation
- [1024](https://github.com/longhorn/website/pull/1024): HugePages node condition
- [1026](https://github.com/longhorn/website/pull/1026): Online encrypted volume expansion
- [1027](https://github.com/longhorn/website/pull/1027): Pre-upgrade manual checks
- [1029](https://github.com/longhorn/website/pull/1029): Volume encryption limitation in COS clusters