### PR TITLE
Update auto-upgrade-engine.adoc

### DIFF
--- a/docs/version-1.8.0/modules/en/pages/upgrades/longhorn-components/auto-upgrade-engine.adoc
+++ b/docs/version-1.8.0/modules/en/pages/upgrades/longhorn-components/auto-upgrade-engine.adoc
@@ -38,8 +38,8 @@ At this time, Longhorn will automatically do offline upgrade for the volume simi
 
 == 3. What Happened If The Upgrade Fails?
 
-If a volume failed to upgrade its engine, the engine image in volume's spec will remain to be different than the engine image in the volume's status.
-Longhorn will continuously retry to upgrade until it succeeds.
+If a volume's engine fails to upgrade, the volume's status won't change. 
+Because the status of the engine image will remain different from the spec, Longhorn will retry the upgrade until it succeeds.
 
 If there are too many volumes that fail to upgrade per node (i.e., more than the `concurrent automatic engine upgrade per node limit` setting),
-Longhorn will stop upgrading volume on that node.
+Longhorn will stop upgrading volumes on that node.


### PR DESCRIPTION
An old update committed in https://github.com/longhorn/website/pull/704 which was closed for unknown reasons. 

Corrected the english (tense/plural, etc) as it is bit hard to follow, especially for some ESL folks. Customers were confused so I just simplified the sentence structure and made minor grammatical adjustments to make it a little clearer and a touch more explicit. How do we fix other versions?