### PR TITLE
Add content from community doc PR:1055

### DIFF
--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -242,7 +242,7 @@ The serviceaccount will require the `roles/storage.objectAdmin` role to read, wr
 +
 Here is a reference to the GCP IAM roles you have available for granting access to a serviceaccount https://cloud.google.com/storage/docs/access-control/iam-roles.
 
-NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to.
+NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
 
 . Navigate to your https://console.cloud.google.com/storage/browser[buckets in cloud storage] and select your newly created bucket.
 . Go to the cloud storage's settings menu and navigate to the https://console.cloud.google.com/storage/settings;tab=interoperability[interoperability tab]
@@ -291,6 +291,8 @@ NOTE: The secret can be named whatever you like as long as they match what's in 
 Once the secret is created and Longhorn's settings are saved, navigate to the backup tab in Longhorn. If there are any issues, they should pop up as a toast notification.
 
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
+
+The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see link:https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
 
 == Set up a Local Testing Backupstore
 

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -295,7 +295,7 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
-The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see link:https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
+The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
 
 == Set up a Local Testing Backupstore
 

--- a/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.8.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -242,7 +242,10 @@ The serviceaccount will require the `roles/storage.objectAdmin` role to read, wr
 +
 Here is a reference to the GCP IAM roles you have available for granting access to a serviceaccount https://cloud.google.com/storage/docs/access-control/iam-roles.
 
-NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
+[NOTE]
+==== 
+Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
+====
 
 . Navigate to your https://console.cloud.google.com/storage/browser[buckets in cloud storage] and select your newly created bucket.
 . Go to the cloud storage's settings menu and navigate to the https://console.cloud.google.com/storage/settings;tab=interoperability[interoperability tab]

--- a/docs/version-1.9.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.9.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -242,7 +242,7 @@ The serviceaccount will require the `roles/storage.objectAdmin` role to read, wr
 +
 Here is a reference to the GCP IAM roles you have available for granting access to a serviceaccount https://cloud.google.com/storage/docs/access-control/iam-roles.
 
-NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to.
+NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
 
 . Navigate to your https://console.cloud.google.com/storage/browser[buckets in cloud storage] and select your newly created bucket.
 . Go to the cloud storage's settings menu and navigate to the https://console.cloud.google.com/storage/settings;tab=interoperability[interoperability tab]
@@ -291,6 +291,8 @@ NOTE: The secret can be named whatever you like as long as they match what's in 
 Once the secret is created and Longhorn's settings are saved, navigate to the backup tab in Longhorn. If there are any issues, they should pop up as a toast notification.
 
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
+
+The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see link:https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
 
 == Set up a Local Testing Backupstore
 

--- a/docs/version-1.9.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
+++ b/docs/version-1.9.0/modules/en/pages/snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc
@@ -242,7 +242,10 @@ The serviceaccount will require the `roles/storage.objectAdmin` role to read, wr
 +
 Here is a reference to the GCP IAM roles you have available for granting access to a serviceaccount https://cloud.google.com/storage/docs/access-control/iam-roles.
 
-NOTE: Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
+[NOTE]
+==== 
+Consider creating an IAM condition to reduce how many buckets this serviceaccount has object admin access to. On the Google Cloud console, go to **Cloud Storage > Buckets**, and select the target bucket. On the **Bucket details** screen, go to the **Permissions** tab, click **Grant Access**, and grant your service account Storage Object Admin permissions for the target bucket.
+====
 
 . Navigate to your https://console.cloud.google.com/storage/browser[buckets in cloud storage] and select your newly created bucket.
 . Go to the cloud storage's settings menu and navigate to the https://console.cloud.google.com/storage/settings;tab=interoperability[interoperability tab]
@@ -292,7 +295,7 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
-The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see link:https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
+The *Backup Target* screen on the {longhorn-product-name} UI displays the status of each backup target. If the status is *Error* and no other details are provided, you can use your browser's *Inspect* feature to view the response data for `/v1/backuptargets`. Errors from GCP are labeled "AWS Error" (for example, `AWS Error: AccessDenied`). For more information, see https://github.com/longhorn/longhorn/issues/10428[Issue #10428].
 
 == Set up a Local Testing Backupstore
 


### PR DESCRIPTION
Scope: v1.8.0, v1.9.0

- [1055](https://github.com/longhorn/website/pull/1055): More hints on configuring GCP backup targets