### PR TITLE
Removed updates made on version greater than 1.7.0

### DIFF
--- a/docs/version-1.7.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.7.0/modules/en/pages/important-notes.adoc
@@ -5,46 +5,22 @@ Please see https://github.com/longhorn/longhorn/releases/tag/v{current-version}[
 
 == Warning
 
-The `longhorn-share-manager` v1.7.3 is affected by a link:https://github.com/nfs-ganesha/nfs-ganesha/issues/1132[regression issue] in `nfs-ganesha` v6.0+. This issue causes unexpected "permission denied" errors when non-root users access `RWX` volumes. To resolve it, replace `longhorn-share-manager:v1.7.3` with the hotfix image `longhorn-share-manager:v1.7.3-hotfix-1`.
+=== Unable to Attach Volumes Created Before v1.5.2 and v1.4.4
 
-You can apply the update in one of the following ways:
+The Longhorn team has identified https://github.com/longhorn/longhorn/issues/9267[a critical issue] that affects volume attachment in Longhorn v1.7.0. A fix for this issue will be included in v1.7.1, which is in active development.
 
-* **Helm or Deployment Manifest**:
-  Update the `longhorn-share-manager` image from `v1.7.3` to `v1.7.3-hotfix-1`, then perform an upgrade.
+Avoid upgrading to v1.7.0 if your Longhorn cluster contains `engine` resources with the following characteristics:
 
-* **Manual Update**:
-  Edit the `longhorn-manager` DaemonSet's `spec.containers.command` field as shown in the example below:
+* Resource name: The format is `<volume name>-e-<8-char random id>`.
+* Time of creation: A Longhorn version earlier than v1.5.2 and v1.4.4 was installed on the cluster.
 
-[,yaml]
+Run the following command to check if you can safely upgrade your Longhorn cluster to v1.7.0:
+
+____
 ----
-  ...
-  spec:
-    containers:
-    - command:
-      - longhorn-manager
-      - -d
-      - daemon
-      - --engine-image
-      - longhornio/longhorn-engine:v1.7.3
-      - --instance-manager-image
-      - longhornio/longhorn-instance-manager:v1.7.3
-      - --share-manager-image
-      - longhornio/longhorn-share-manager:v1.7.3-hotfix-1
-      - --backing-image-manager-image
-      - longhornio/backing-image-manager:v1.7.3
-      - --support-bundle-manager-image
-      - longhornio/support-bundle-kit:v0.0.51
-      - --manager-image
-      - longhornio/longhorn-manager:v1.7.3
-      - --service-account
-      - longhorn-service-account
-      - --upgrade-version-check
-  ...
+[ $(kubectl -n longhorn-system get engines.longhorn.io -o name | grep -E '\-e\-[a-z0-9]{8}$' | wc -l) -gt 0 ] && echo "Please hold off on upgrading to v1.7.0 until v1.7.1 is available." || echo "Safe to upgrade to v1.7.0."
 ----
-
-After the update, newly created `RWX` volumes will use the hotfix image. For existing attached `RWX` volumes, you can detach and then reattach them to apply the hotfix.
-
-For more information, see link:https://github.com/longhorn/longhorn/issues/10979[Issue #10979] and link:https://github.com/longhorn/longhorn/issues/10621[Issue #10621].
+____
 
 == Deprecation
 

--- a/docs/version-1.7.0/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.7.0/modules/en/pages/important-notes.adoc
@@ -58,17 +58,6 @@ The functionality of the https://github.com/longhorn/longhorn/blob/master/script
 
 Please ensure your Kubernetes cluster is at least v1.21 before upgrading to Longhorn v{current-version} because this is the minimum version Longhorn v{current-version} supports.
 
-=== CRD Upgrade Validation
-
-During an upgrade, the Custom Resource Definition (CRD) might be applied after the new Longhorn Manager starts. This order helps prevent the controller from processing objects that contain deprecated data or fields. However, this sequencing can cause the Longhorn Manager to fail during the initial upgrade phase if the CRD is not yet applied.
-
-If the Longhorn Manager crashes during the upgrade, check the logs to determine if the CRD not being applied is the cause of the failure. In such cases, the logs might contain error messages similar to the following:
-
-[,log]
-----
-time="2025-03-27T06:59:55Z" level=fatal msg="Error starting manager: upgrade resources failed: BackingImage in version \"v1beta2\" cannot be handled as a BackingImage: strict decoding error: unknown field \"spec.diskFileSpecMap\", unknown field \"spec.diskSelector\", unknown field \"spec.minNumberOfCopies\", unknown field \"spec.nodeSelector\", unknown field \"spec.secret\", unknown field \"spec.secretNamespace\"" func=main.main.DaemonCmd.func3 file="daemon.go:94"
-----
-
 === Pod Security Policies Disabled & Pod Security Admission Introduction
 
 * Longhorn pods require privileged access to manage nodes' storage. In Longhorn `v1.3.x` or older, Longhorn was shipping some Pod Security Policies by default, (e.g., https://github.com/longhorn/longhorn/blob/4ba39a989b4b482d51fd4bc651f61f2b419428bd/chart/values.yaml#L260[link]).

--- a/docs/version-1.7.0/modules/en/pages/installation-setup/best-practices.adoc
+++ b/docs/version-1.7.0/modules/en/pages/installation-setup/best-practices.adoc
@@ -106,17 +106,17 @@ We recommend running your Kubernetes cluster on one of the following versions. T
 |===
 | Release | Released | End-of-life
 
-| 1.32
-| 11 Dec 2024
-| 28 Feb 2026
+| 1.28
+| 15 Aug 2023
+| 28 Oct 2024
 
-| 1.31
-| 13 Aug 2024
-| 28 Oct 2025
+| 1.27
+| 11 Apr 2023
+| 28 Jun 2024
 
-| 1.30
-| 17 Apr 2024
-| 28 Jun 2025
+| 1.26
+| 08 Dec 2022
+| 28 Feb 2024
 |===
 
 Referenced to https://endoflife.date/kubernetes.

--- a/docs/version-1.7.0/modules/en/pages/installation-setup/installation/helm-values.adoc
+++ b/docs/version-1.7.0/modules/en/pages/installation-setup/installation/helm-values.adoc
@@ -69,7 +69,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.attacher.tag
 | string
-| `"v4.8.0"`
+| `"v4.4.2"`
 | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
 
 | image.csi.livenessProbe.repository
@@ -79,7 +79,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.livenessProbe.tag
 | string
-| `"v2.15.0"`
+| `"v2.12.0"`
 | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
 
 | image.csi.nodeDriverRegistrar.repository
@@ -89,7 +89,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.nodeDriverRegistrar.tag
 | string
-| `"v2.13.0"`
+| `"v2.9.2"`
 | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
 
 | image.csi.provisioner.repository
@@ -99,7 +99,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.provisioner.tag
 | string
-| `"v4.0.1-20250204"`
+| `"v3.6.2"`
 | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
 
 | image.csi.resizer.repository
@@ -109,7 +109,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.resizer.tag
 | string
-| `"v1.13.1"`
+| `"v1.9.2"`
 | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
 
 | image.csi.snapshotter.repository
@@ -119,7 +119,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.csi.snapshotter.tag
 | string
-| `"v7.0.2-20250204"`
+| `"v3.6.2"`
 | Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
 
 | image.longhorn.backingImageManager.repository
@@ -179,7 +179,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 
 | image.longhorn.supportBundleKit.tag
 | string
-| `"v0.0.51"`
+| `"v0.0.37"`
 | Tag for the Longhorn Support Bundle Manager image.
 
 | image.longhorn.ui.repository


### PR DESCRIPTION
Scope: v1.7.0

- [193](https://github.com/rancher/longhorn-product-docs/pull/193)
    - [1056](https://github.com/longhorn/website/pull/1056)
    - [1057](https://github.com/longhorn/website/pull/1057)
- [202](https://github.com/rancher/longhorn-product-docs/pull/202)
    - [1081](https://github.com/longhorn/website/pull/1081)
- [219](https://github.com/rancher/longhorn-product-docs/pull/219)
    - [1120](https://github.com/longhorn/website/pull/1120)
    - [1121](https://github.com/longhorn/website/pull/1121)