### PR TITLE
Stop Antora stripping trailing 0 from the version number. 

### DIFF
--- a/docs/version-1.10/antora.yml
+++ b/docs/version-1.10/antora.yml
@@ -1,6 +1,6 @@
 name: storage
 title: SUSE® Storage
-version: 1.10
+version: '1.10'
 prerelease: (Dev)
 start_page: en:longhorn-documentation.adoc
 nav:


### PR DESCRIPTION
A bug in Antora?