### PR TITLE
Updated the format of docs

### DIFF
--- a/docs/version-1.10/modules/en/pages/nodes/default-disk-and-node-config.adoc
+++ b/docs/version-1.10/modules/en/pages/nodes/default-disk-and-node-config.adoc
@@ -1,45 +1,43 @@
 = Configure Default Node and Disk Settings
 :current-version: {page-component-version}
 
-This feature allows the user to customize the default disks and node configurations in Longhorn for newly added nodes using Kubernetes labels and annotations instead of the Longhorn API or UI.
+This feature allows the user to customize the default disks and node configurations in {longhorn-product-name} for newly added nodes using Kubernetes labels and annotations instead of the {longhorn-product-name} UI or API.
 
-Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure Longhorn manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
+Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure {longhorn-product-name} manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
 
-Longhorn will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will Longhorn keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
+{longhorn-product-name} will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will {longhorn-product-name} keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
 
 == Adding Node Tags to New Nodes
 
-When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the Longhorn UI or API.
+When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the {longhorn-product-name} UI or API.
 
 . Scale up the Kubernetes cluster. The newly added nodes contain no node tags.
 . Add annotations to the new Kubernetes nodes that specify what the default node tags should be. The annotation format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: <node tag list with JSON string format>
+node.longhorn.io/default-node-tags: <node tag list with JSON string format>
 ----
 +
 For example:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: '["fast","storage"]'
+node.longhorn.io/default-node-tags: '["fast","storage"]'
 ----
 
-. Wait for Longhorn to sync the node tag automatically.
-
-____
-*Result:* If the node tag list was originally empty, Longhorn updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
+. Wait for {longhorn-product-name} to sync the node tag automatically. If the node tag list was originally empty, {longhorn-product-name} updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
 
 == Customizing Default Disks for New Nodes
-____
 
-Longhorn uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
+{longhorn-product-name} uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
 
-If the setting is disabled, Longhorn will create a default disk using `setting.default-data-path` on all new nodes.
+If the setting is disabled, {longhorn-product-name} will create a default disk using `setting.default-data-path` on all new nodes.
 
-If the setting is enabled, Longhorn will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
+If the setting is enabled, {longhorn-product-name} will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
 
-* If the node's label value is `true`, Longhorn will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, Longhorn will not change anything.
-* If the node's label value is `config`, Longhorn will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, Longhorn will not change anything.
+* If the node's label value is `true`, {longhorn-product-name} will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, {longhorn-product-name} will not change anything.
+* If the node's label value is `config`, {longhorn-product-name} will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, {longhorn-product-name} will not change anything.
 
 The value of the label will be in effect only when the setting is enabled.
 
@@ -49,67 +47,71 @@ The configuration described in the annotation only takes effect when there are n
 
 If the label or annotation fails validation, the whole annotation is ignored.
 
-____
-*Prerequisite:* The Longhorn setting *Create Default Disk on Labeled Nodes* must be enabled.
+=== Prerequisite
+
+The {longhorn-product-name} setting *Create Default Disk on Labeled Nodes* must be enabled.
 
 . Add new nodes to the Kubernetes cluster.
-. Add the label to the node. Longhorn relies on the label to decide how to customize default disks:
-____
-
- ```
- node.longhorn.io/create-default-disk: 'config'
- ```
+. Add the label to the node. {longhorn-product-name} relies on the label to decide how to customize default disks:
++
+[,yaml]
+----
+node.longhorn.io/create-default-disk: 'config'
+----
 
 . Then add an annotation to the node. The annotation is used to specify the configuration of default disks. The format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
+node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
 ----
 +
 For example, the following disk configuration can be specified in the annotation:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config:
- '[
-     {
-         "path":"/mnt/disk1",
-         "allowScheduling":true
-     },
-     {
-         "name":"fast-ssd-disk",
-         "path":"/mnt/disk2",
-         "allowScheduling":false,
-         "storageReserved":10485760,
-         "tags":[
-             "ssd",
-             "fast"
-         ]
-     }
- ]'
+node.longhorn.io/default-disks-config:
+'[
+    {
+        "path":"/mnt/disk1",
+        "allowScheduling":true
+    },
+    {
+        "name":"fast-ssd-disk",
+        "path":"/mnt/disk2",
+        "allowScheduling":false,
+        "storageReserved":10485760,
+        "tags":[
+            "ssd",
+            "fast"
+        ]
+    }
+]'
 ----
 +
-NOTE: If the same name is specified for different disks, the configuration will be treated as invalid.
+[NOTE]
+====
+If the same name is specified for different disks, the configuration will be treated as invalid.
+====
 
-. Wait for Longhorn to create the customized default disks automatically.
+. Wait for {longhorn-product-name} to create the customized default disks automatically, according to the annotation.
 
-____
-*Result:* The disks will be updated according to the annotation.
-____
+== Launch {longhorn-product-name} with multiple disks
 
-== Launch Longhorn with multiple disks
-
-. Add the label to all nodes before launching Longhorn.
+. Add the label to all nodes before launching {longhorn-product-name}.
 +
+[,yaml]
 ----
- node.longhorn.io/create-default-disk: 'config'
+node.longhorn.io/create-default-disk: 'config'
 ----
 
 . Then add the disk config annotation to all nodes:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
-   }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
-   "tags":[ "ssd", "fast" ] }]'
+node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
+  }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
+  "tags":[ "ssd", "fast" ] }]'
 ----
 
-. Deploy Longhorn with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of Longhorn.
+. Deploy {longhorn-product-name} with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of {longhorn-product-name}.

--- a/docs/version-1.7/modules/en/pages/nodes/default-disk-and-node-config.adoc
+++ b/docs/version-1.7/modules/en/pages/nodes/default-disk-and-node-config.adoc
@@ -1,45 +1,43 @@
 = Configure Default Node and Disk Settings
 :current-version: {page-component-version}
 
-This feature allows the user to customize the default disks and node configurations in Longhorn for newly added nodes using Kubernetes labels and annotations instead of the Longhorn API or UI.
+This feature allows the user to customize the default disks and node configurations in {longhorn-product-name} for newly added nodes using Kubernetes labels and annotations instead of the {longhorn-product-name} UI or API.
 
-Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure Longhorn manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
+Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure {longhorn-product-name} manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
 
-Longhorn will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will Longhorn keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
+{longhorn-product-name} will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will {longhorn-product-name} keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
 
 == Adding Node Tags to New Nodes
 
-When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the Longhorn UI or API.
+When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the {longhorn-product-name} UI or API.
 
 . Scale up the Kubernetes cluster. The newly added nodes contain no node tags.
 . Add annotations to the new Kubernetes nodes that specify what the default node tags should be. The annotation format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: <node tag list with JSON string format>
+node.longhorn.io/default-node-tags: <node tag list with JSON string format>
 ----
 +
 For example:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: '["fast","storage"]'
+node.longhorn.io/default-node-tags: '["fast","storage"]'
 ----
 
-. Wait for Longhorn to sync the node tag automatically.
-
-____
-*Result:* If the node tag list was originally empty, Longhorn updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
+. Wait for {longhorn-product-name} to sync the node tag automatically. If the node tag list was originally empty, {longhorn-product-name} updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
 
 == Customizing Default Disks for New Nodes
-____
 
-Longhorn uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
+{longhorn-product-name} uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
 
-If the setting is disabled, Longhorn will create a default disk using `setting.default-data-path` on all new nodes.
+If the setting is disabled, {longhorn-product-name} will create a default disk using `setting.default-data-path` on all new nodes.
 
-If the setting is enabled, Longhorn will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
+If the setting is enabled, {longhorn-product-name} will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
 
-* If the node's label value is `true`, Longhorn will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, Longhorn will not change anything.
-* If the node's label value is `config`, Longhorn will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, Longhorn will not change anything.
+* If the node's label value is `true`, {longhorn-product-name} will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, {longhorn-product-name} will not change anything.
+* If the node's label value is `config`, {longhorn-product-name} will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, {longhorn-product-name} will not change anything.
 
 The value of the label will be in effect only when the setting is enabled.
 
@@ -49,67 +47,71 @@ The configuration described in the annotation only takes effect when there are n
 
 If the label or annotation fails validation, the whole annotation is ignored.
 
-____
-*Prerequisite:* The Longhorn setting *Create Default Disk on Labeled Nodes* must be enabled.
+=== Prerequisite
+
+The {longhorn-product-name} setting *Create Default Disk on Labeled Nodes* must be enabled.
 
 . Add new nodes to the Kubernetes cluster.
-. Add the label to the node. Longhorn relies on the label to decide how to customize default disks:
-____
-
- ```
- node.longhorn.io/create-default-disk: 'config'
- ```
+. Add the label to the node. {longhorn-product-name} relies on the label to decide how to customize default disks:
++
+[,yaml]
+----
+node.longhorn.io/create-default-disk: 'config'
+----
 
 . Then add an annotation to the node. The annotation is used to specify the configuration of default disks. The format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
+node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
 ----
 +
 For example, the following disk configuration can be specified in the annotation:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config:
- '[
-     {
-         "path":"/mnt/disk1",
-         "allowScheduling":true
-     },
-     {
-         "name":"fast-ssd-disk",
-         "path":"/mnt/disk2",
-         "allowScheduling":false,
-         "storageReserved":10485760,
-         "tags":[
-             "ssd",
-             "fast"
-         ]
-     }
- ]'
+node.longhorn.io/default-disks-config:
+'[
+    {
+        "path":"/mnt/disk1",
+        "allowScheduling":true
+    },
+    {
+        "name":"fast-ssd-disk",
+        "path":"/mnt/disk2",
+        "allowScheduling":false,
+        "storageReserved":10485760,
+        "tags":[
+            "ssd",
+            "fast"
+        ]
+    }
+]'
 ----
 +
-NOTE: If the same name is specified for different disks, the configuration will be treated as invalid.
+[NOTE]
+====
+If the same name is specified for different disks, the configuration will be treated as invalid.
+====
 
-. Wait for Longhorn to create the customized default disks automatically.
+. Wait for {longhorn-product-name} to create the customized default disks automatically, according to the annotation.
 
-____
-*Result:* The disks will be updated according to the annotation.
-____
+== Launch {longhorn-product-name} with multiple disks
 
-== Launch Longhorn with multiple disks
-
-. Add the label to all nodes before launching Longhorn.
+. Add the label to all nodes before launching {longhorn-product-name}.
 +
+[,yaml]
 ----
- node.longhorn.io/create-default-disk: 'config'
+node.longhorn.io/create-default-disk: 'config'
 ----
 
 . Then add the disk config annotation to all nodes:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
-   }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
-   "tags":[ "ssd", "fast" ] }]'
+node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
+  }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
+  "tags":[ "ssd", "fast" ] }]'
 ----
 
-. Deploy Longhorn with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of Longhorn.
+. Deploy {longhorn-product-name} with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of {longhorn-product-name}.

--- a/docs/version-1.8/modules/en/pages/nodes/default-disk-and-node-config.adoc
+++ b/docs/version-1.8/modules/en/pages/nodes/default-disk-and-node-config.adoc
@@ -1,45 +1,43 @@
 = Configure Default Node and Disk Settings
 :current-version: {page-component-version}
 
-This feature allows the user to customize the default disks and node configurations in Longhorn for newly added nodes using Kubernetes labels and annotations instead of the Longhorn API or UI.
+This feature allows the user to customize the default disks and node configurations in {longhorn-product-name} for newly added nodes using Kubernetes labels and annotations instead of the {longhorn-product-name} UI or API.
 
-Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure Longhorn manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
+Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure {longhorn-product-name} manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
 
-Longhorn will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will Longhorn keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
+{longhorn-product-name} will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will {longhorn-product-name} keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
 
 == Adding Node Tags to New Nodes
 
-When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the Longhorn UI or API.
+When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the {longhorn-product-name} UI or API.
 
 . Scale up the Kubernetes cluster. The newly added nodes contain no node tags.
 . Add annotations to the new Kubernetes nodes that specify what the default node tags should be. The annotation format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: <node tag list with JSON string format>
+node.longhorn.io/default-node-tags: <node tag list with JSON string format>
 ----
 +
 For example:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: '["fast","storage"]'
+node.longhorn.io/default-node-tags: '["fast","storage"]'
 ----
 
-. Wait for Longhorn to sync the node tag automatically.
-
-____
-*Result:* If the node tag list was originally empty, Longhorn updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
+. Wait for {longhorn-product-name} to sync the node tag automatically. If the node tag list was originally empty, {longhorn-product-name} updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
 
 == Customizing Default Disks for New Nodes
-____
 
-Longhorn uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
+{longhorn-product-name} uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
 
-If the setting is disabled, Longhorn will create a default disk using `setting.default-data-path` on all new nodes.
+If the setting is disabled, {longhorn-product-name} will create a default disk using `setting.default-data-path` on all new nodes.
 
-If the setting is enabled, Longhorn will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
+If the setting is enabled, {longhorn-product-name} will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
 
-* If the node's label value is `true`, Longhorn will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, Longhorn will not change anything.
-* If the node's label value is `config`, Longhorn will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, Longhorn will not change anything.
+* If the node's label value is `true`, {longhorn-product-name} will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, {longhorn-product-name} will not change anything.
+* If the node's label value is `config`, {longhorn-product-name} will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, {longhorn-product-name} will not change anything.
 
 The value of the label will be in effect only when the setting is enabled.
 
@@ -49,67 +47,71 @@ The configuration described in the annotation only takes effect when there are n
 
 If the label or annotation fails validation, the whole annotation is ignored.
 
-____
-*Prerequisite:* The Longhorn setting *Create Default Disk on Labeled Nodes* must be enabled.
+=== Prerequisite
+
+The {longhorn-product-name} setting *Create Default Disk on Labeled Nodes* must be enabled.
 
 . Add new nodes to the Kubernetes cluster.
-. Add the label to the node. Longhorn relies on the label to decide how to customize default disks:
-____
-
- ```
- node.longhorn.io/create-default-disk: 'config'
- ```
+. Add the label to the node. {longhorn-product-name} relies on the label to decide how to customize default disks:
++
+[,yaml]
+----
+node.longhorn.io/create-default-disk: 'config'
+----
 
 . Then add an annotation to the node. The annotation is used to specify the configuration of default disks. The format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
+node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
 ----
 +
 For example, the following disk configuration can be specified in the annotation:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config:
- '[
-     {
-         "path":"/mnt/disk1",
-         "allowScheduling":true
-     },
-     {
-         "name":"fast-ssd-disk",
-         "path":"/mnt/disk2",
-         "allowScheduling":false,
-         "storageReserved":10485760,
-         "tags":[
-             "ssd",
-             "fast"
-         ]
-     }
- ]'
+node.longhorn.io/default-disks-config:
+'[
+    {
+        "path":"/mnt/disk1",
+        "allowScheduling":true
+    },
+    {
+        "name":"fast-ssd-disk",
+        "path":"/mnt/disk2",
+        "allowScheduling":false,
+        "storageReserved":10485760,
+        "tags":[
+            "ssd",
+            "fast"
+        ]
+    }
+]'
 ----
 +
-NOTE: If the same name is specified for different disks, the configuration will be treated as invalid.
+[NOTE]
+====
+If the same name is specified for different disks, the configuration will be treated as invalid.
+====
 
-. Wait for Longhorn to create the customized default disks automatically.
+. Wait for {longhorn-product-name} to create the customized default disks automatically, according to the annotation.
 
-____
-*Result:* The disks will be updated according to the annotation.
-____
+== Launch {longhorn-product-name} with multiple disks
 
-== Launch Longhorn with multiple disks
-
-. Add the label to all nodes before launching Longhorn.
+. Add the label to all nodes before launching {longhorn-product-name}.
 +
+[,yaml]
 ----
- node.longhorn.io/create-default-disk: 'config'
+node.longhorn.io/create-default-disk: 'config'
 ----
 
 . Then add the disk config annotation to all nodes:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
-   }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
-   "tags":[ "ssd", "fast" ] }]'
+node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
+  }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
+  "tags":[ "ssd", "fast" ] }]'
 ----
 
-. Deploy Longhorn with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of Longhorn.
+. Deploy {longhorn-product-name} with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of {longhorn-product-name}.

--- a/docs/version-1.9/modules/en/pages/nodes/default-disk-and-node-config.adoc
+++ b/docs/version-1.9/modules/en/pages/nodes/default-disk-and-node-config.adoc
@@ -1,45 +1,43 @@
 = Configure Default Node and Disk Settings
 :current-version: {page-component-version}
 
-This feature allows the user to customize the default disks and node configurations in Longhorn for newly added nodes using Kubernetes labels and annotations instead of the Longhorn API or UI.
+This feature allows the user to customize the default disks and node configurations in {longhorn-product-name} for newly added nodes using Kubernetes labels and annotations instead of the {longhorn-product-name} UI or API.
 
-Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure Longhorn manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
+Customizing the default configurations for disks and nodes is useful for scaling the cluster because it eliminates the need to configure {longhorn-product-name} manually for each new node if the node contains more than one disk, or if the disk configuration is different for new nodes.
 
-Longhorn will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will Longhorn keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
+{longhorn-product-name} will not keep the node labels or annotations in sync with the current Longhorn node disks or tags. Nor will {longhorn-product-name} keep the node disks or tags in sync with the nodes, labels or annotations after the default disks or tags have been created.
 
 == Adding Node Tags to New Nodes
 
-When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the Longhorn UI or API.
+When a node does not have a tag, you can use a node annotation to set the node tags, as an alternative to using the {longhorn-product-name} UI or API.
 
 . Scale up the Kubernetes cluster. The newly added nodes contain no node tags.
 . Add annotations to the new Kubernetes nodes that specify what the default node tags should be. The annotation format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: <node tag list with JSON string format>
+node.longhorn.io/default-node-tags: <node tag list with JSON string format>
 ----
 +
 For example:
 +
+[,yaml]
 ----
- node.longhorn.io/default-node-tags: '["fast","storage"]'
+node.longhorn.io/default-node-tags: '["fast","storage"]'
 ----
 
-. Wait for Longhorn to sync the node tag automatically.
-
-____
-*Result:* If the node tag list was originally empty, Longhorn updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
+. Wait for {longhorn-product-name} to sync the node tag automatically. If the node tag list was originally empty, {longhorn-product-name} updates the node with the tag list, and you will see the tags for that node updated according to the annotation. If the node already had tags, you will see no change to the tag list.
 
 == Customizing Default Disks for New Nodes
-____
 
-Longhorn uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
+{longhorn-product-name} uses the *Create Default Disk on Labeled Nodes* setting to enable default disk customization.
 
-If the setting is disabled, Longhorn will create a default disk using `setting.default-data-path` on all new nodes.
+If the setting is disabled, {longhorn-product-name} will create a default disk using `setting.default-data-path` on all new nodes.
 
-If the setting is enabled, Longhorn will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
+If the setting is enabled, {longhorn-product-name} will decide to create the default disks or not, depending on the node's label value of `node.longhorn.io/create-default-disk`.
 
-* If the node's label value is `true`, Longhorn will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, Longhorn will not change anything.
-* If the node's label value is `config`, Longhorn will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, Longhorn will not change anything.
+* If the node's label value is `true`, {longhorn-product-name} will create the default disk using `settings.default-data-path` on the node. If the node already has existing disks, {longhorn-product-name} will not change anything.
+* If the node's label value is `config`, {longhorn-product-name} will check for the `node.longhorn.io/default-disks-config` annotation and create default disks according to it. If there is no annotation, or if the annotation is invalid, or the label value is invalid, {longhorn-product-name} will not change anything.
 
 The value of the label will be in effect only when the setting is enabled.
 
@@ -49,67 +47,71 @@ The configuration described in the annotation only takes effect when there are n
 
 If the label or annotation fails validation, the whole annotation is ignored.
 
-____
-*Prerequisite:* The Longhorn setting *Create Default Disk on Labeled Nodes* must be enabled.
+=== Prerequisite
+
+The {longhorn-product-name} setting *Create Default Disk on Labeled Nodes* must be enabled.
 
 . Add new nodes to the Kubernetes cluster.
-. Add the label to the node. Longhorn relies on the label to decide how to customize default disks:
-____
-
- ```
- node.longhorn.io/create-default-disk: 'config'
- ```
+. Add the label to the node. {longhorn-product-name} relies on the label to decide how to customize default disks:
++
+[,yaml]
+----
+node.longhorn.io/create-default-disk: 'config'
+----
 
 . Then add an annotation to the node. The annotation is used to specify the configuration of default disks. The format is:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
+node.longhorn.io/default-disks-config: <disks configuration with JSON string format>
 ----
 +
 For example, the following disk configuration can be specified in the annotation:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config:
- '[
-     {
-         "path":"/mnt/disk1",
-         "allowScheduling":true
-     },
-     {
-         "name":"fast-ssd-disk",
-         "path":"/mnt/disk2",
-         "allowScheduling":false,
-         "storageReserved":10485760,
-         "tags":[
-             "ssd",
-             "fast"
-         ]
-     }
- ]'
+node.longhorn.io/default-disks-config:
+'[
+    {
+        "path":"/mnt/disk1",
+        "allowScheduling":true
+    },
+    {
+        "name":"fast-ssd-disk",
+        "path":"/mnt/disk2",
+        "allowScheduling":false,
+        "storageReserved":10485760,
+        "tags":[
+            "ssd",
+            "fast"
+        ]
+    }
+]'
 ----
 +
-NOTE: If the same name is specified for different disks, the configuration will be treated as invalid.
+[NOTE]
+====
+If the same name is specified for different disks, the configuration will be treated as invalid.
+====
 
-. Wait for Longhorn to create the customized default disks automatically.
+. Wait for {longhorn-product-name} to create the customized default disks automatically, according to the annotation.
 
-____
-*Result:* The disks will be updated according to the annotation.
-____
+== Launch {longhorn-product-name} with multiple disks
 
-== Launch Longhorn with multiple disks
-
-. Add the label to all nodes before launching Longhorn.
+. Add the label to all nodes before launching {longhorn-product-name}.
 +
+[,yaml]
 ----
- node.longhorn.io/create-default-disk: 'config'
+node.longhorn.io/create-default-disk: 'config'
 ----
 
 . Then add the disk config annotation to all nodes:
 +
+[,yaml]
 ----
- node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
-   }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
-   "tags":[ "ssd", "fast" ] }]'
+node.longhorn.io/default-disks-config: '[ { "path":"/var/lib/longhorn", "allowScheduling":true
+  }, { "name":"fast-ssd-disk", "path":"/mnt/extra", "allowScheduling":false, "storageReserved":10485760,
+  "tags":[ "ssd", "fast" ] }]'
 ----
 
-. Deploy Longhorn with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of Longhorn.
+. Deploy {longhorn-product-name} with `create-default-disk-labeled-nodes: true`, check xref:longhorn-system//customize-default-settings.adoc[here] for customizing the default settings of {longhorn-product-name}.


### PR DESCRIPTION
**Scope**: v1.7, v1.8, v1.9, and v1.10

**Reason**: The format was incorrect. [Link](https://documentation.suse.com/cloudnative/storage/1.7/en/nodes/default-disk-and-node-config.html#_launch_longhorn_with_multiple_disks)
