### PR TITLE
Fix: links, indentation, variable rendering

### DIFF
--- a/docs/version-1.10/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
+++ b/docs/version-1.10/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
@@ -20,6 +20,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 . Introduce disks containing orphaned replica directories.
  ** Orphaned replica directories on Node `worker1` disks
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-15a210ed
@@ -27,6 +28,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 
  ** Orphaned replica directories on Node `worker2` disks
 +
+[,console]
 ----
 # ls /var/lib/longhorn/replicas/
  pvc-28255b31-161f-5621-eea3-a1cbafb4a12a-866aa0a5
@@ -37,6 +39,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 
 . {longhorn-product-name} detects the orphaned replica directories and creates an `orphan` resources describing the directories.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get orphans -l "longhorn.io/orphan-type=replica"
  NAME                                                                      TYPE      NODE
@@ -47,12 +50,15 @@ The following example demonstrate how to manage orphaned replica directories ide
 
 . Retrieve a list of orphaned resources created by {longhorn-product-name} using the command `kubectl -n longhorn-system get orphan`.
 +
+[,console]
 ----
  kubectl -n longhorn-system get orphan
 ----
 
-. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubcel -n longhorn-system get orphan <name>`.
-```
+. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubectl -n longhorn-system get orphan <name>`.
++
+[,yaml]
+----
  # kubectl -n longhorn-system get orphans orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272 -o yaml
  apiVersion: longhorn.io/v1beta2
  kind: Orphan
@@ -67,9 +73,8 @@ The following example demonstrate how to manage orphaned replica directories ide
   longhorn.io/orphan-type: replica
   longhornnode: rancher60-worker1
 
-+
 ......
-+
+
 spec:
  nodeID: rancher60-worker1
  orphanType: replica
@@ -93,9 +98,11 @@ spec:
   status: "False"
   type: Error
  ownerID: rancher60-worker1
-```
+----
+
 . One can delete the `orphan` resource by `kubectl -n longhorn-system delete orphan <name>` and then the corresponding orphaned replica directory will be deleted.
 +
+[,console]
 ----
  # kubectl -n longhorn-system delete orphan orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272
 
@@ -107,18 +114,21 @@ spec:
 +
 The orphaned replica directory is deleted.
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
 ----
 
 . By default, {longhorn-product-name} will not automatically delete the orphaned replica directory. You can enable automatic deletion by setting the `orphan-resource-auto-deletion` setting.
 +
+[,console]
 ----
  # kubectl -n longhorn-system edit settings.longhorn.io orphan-resource-auto-deletion
 ----
 +
 Then, add `replica-data` to the list by including it as one of the semicolon-separated items.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get settings.longhorn.io orphan-resource-auto-deletion
  NAME                           VALUE          APPLIED     AGE
@@ -127,6 +137,7 @@ Then, add `replica-data` to the list by including it as one of the semicolon-sep
 
 . After enabling the automatic deletion and wait for a while, the `orphan` resources and directories are deleted automatically.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get orphans.longhorn.io -l "longhorn.io/orphan-type=replica"
  No resources found in longhorn-system namespace.
@@ -134,6 +145,7 @@ Then, add `replica-data` to the list by including it as one of the semicolon-sep
 +
 The orphaned replica directories are deleted.
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
 
@@ -142,6 +154,7 @@ The orphaned replica directories are deleted.
 +
 Additionally, one can delete all orphaned replica directories on the specified node by
 +
+[,console]
 ----
  # kubectl -n longhorn-system delete orphan -l "longhorn.io/orphan-type=replica-instance,longhornnode=<node name>”
 ----

--- a/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-flux.adoc
+++ b/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-flux.adoc
@@ -99,10 +99,11 @@ Example of a successful installation:
 
 You can commit and push exported manifests to your GitOps repository.
 
- ```bash
- git add helmrepo.yaml helmrelease.yaml
- git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
- git push origin <branch_name>
- ```
+[subs="+attributes",bash]
+----
+git add helmrepo.yaml helmrelease.yaml
+git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
+git push origin <branch_name>
+----
 
 Afterwards, you can modify the HelmRelease and HelmRepository CRs by editing the YAML manifests in your GitOps repository. Flux automatically detects and applies the changes without requiring direct access to your Kubernetes cluster.

--- a/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -21,7 +21,7 @@ ____
 
 . Create a HelmChart YAML file similar to the following:
 +
-[,yaml]
+[subs="+attributes",yaml]
 ----
 apiVersion: helm.cattle.io/v1
   kind: HelmChart
@@ -34,7 +34,7 @@ apiVersion: helm.cattle.io/v1
     name: longhorn-install
     namespace: default
   spec:
-    version: v{{< current-version >}}
+    version: v{patch-version}
     chart: longhorn
     repo: https://charts.longhorn.io
     failurePolicy: abort
@@ -71,7 +71,7 @@ Deleting the HelmChart CR initiates uninstallation of {longhorn-product-name}.
 ====
 . Check the created resources.
 +
-[,shell]
+[subs="+attributes",shell]
 ----
 $ kubectl get jobs
 NAME                            COMPLETIONS   DURATION   AGE
@@ -81,7 +81,7 @@ NAME                                  READY   STATUS      RESTARTS   AGE
 helm-install-longhorn-install-lngm8   0/1     Completed   0          25s
 $ kubectl get helmcharts
 NAME               JOB                     CHART      TARGETNAMESPACE   VERSION   REPO                         HELMVERSION   BOOTSTRAP
-longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{{< current-version >}}    https://charts.longhorn.io
+longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{patch-version}   https://charts.longhorn.io
 ----
 +
 . Verify that the deployment succeeded.

--- a/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.10/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -15,7 +15,7 @@ ____
 
 [NOTE]
 ====
-* The initial settings can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
+* The initial settings can be xref:longhorn-system/customize-default-settings.adoc#_using_helm[customized using Helm options or by editing the deployment configuration file].
 * For Kubernetes v1.25 or earlier, if your cluster still enables Pod Security Policy admission controller, set the helm value `enablePSP` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
 ====
 
@@ -47,11 +47,13 @@ apiVersion: helm.cattle.io/v1
 * Ensure that `spec.failurePolicy` is set to "abort".  The only other value is the default: "reinstall", which uninstalls {longhorn-product-name}.  With "abort", it retries periodically, giving the user a chance to fix the problem.
 +
 * Rather than specify the repo, version, and chart name, the yaml can also use an image of the charts themselves:
++
 [,yaml]
 ----
 spec:
   chartContent:  <tarball of chart directory | base64 -w 0>
 ----
++
 For full details see the HelmChart controller docs: https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html[{rke2-product-name} - Helm] or https://documentation.suse.com/cloudnative/k3s/latest/en/helm.html[{k3s-product-name} - Helm].
 ====
 +

--- a/docs/version-1.10/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
+++ b/docs/version-1.10/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
@@ -41,12 +41,13 @@ helm install longhorn longhorn/longhorn \
 
 === Install With `oc` Command
 
-Perform the following steps to install Longhorn on [OKD](https://www.okd.io/) clusters.
+Perform the following steps to install Longhorn on https://www.okd.io/[OKD] clusters.
 
 . Download the `longhorn-okd.yaml` file.
 +
+[subs="+attributes",bash]
 ----
-wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-okd.yaml
+wget https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn-okd.yaml
 ----
 +
 . Specify the target `oauth-proxy` container image in the `longhorn-okd.yaml` file (for example, `quay.io/openshift/origin-oauth-proxy:4.15`).
@@ -80,7 +81,7 @@ To understand more about configuring the disks for {longhorn-product-name}, plea
 --set defaultSettings.createDefaultDiskLabeledNodes=true
 ----
 
-And then add another device formatted for {longhorn-product-name}
+And then add another device formatted for {longhorn-product-name}.
 
 === Add An Extra Disk for {longhorn-product-name}
 
@@ -106,7 +107,7 @@ sudo mkfs.ext4 -L longhorn /dev/${DEVICE_NAME}
 
 The secondary drive needs to be mounted automatically when node boots up by the `MachineConfig` that can be created and deployed by:
 
-[subs="+attributes",bash]
+[subs="+attributes",yaml]
 ----
 cat <<EOF >>auto-mount-machineconfig.yaml
 apiVersion: machineconfiguration.openshift.io/v1
@@ -150,7 +151,10 @@ oc annotate node ${NODE_NAME} --overwrite node.longhorn.io/default-disks-config=
 oc label node ${NODE_NAME} --overwrite node.longhorn.io/create-default-disk=config
 ----
 
-NOTE: You might need to reboot the node to validate the modified configuration.
+[NOTE]
+====
+You might need to reboot the node to validate the modified configuration.
+====
 
 == Reference
 

--- a/docs/version-1.10/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.10/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -9,7 +9,7 @@ You must meet the following requirements before installing {longhorn-product-nam
 
 Some {longhorn-product-name}-dependent binary executables are not present in the default Talos root filesystem. To have access to these binaries, Talos offers system extension mechanism to extend the installation.
 
-* `siderolabs/iscsi-tools`: this extension enables iscsid daemon and iscsiadm to be available to all nodes for the Kubernetes persistent volumes operations.
+* `siderolabs/iscsi-tools`: this extension enables `iscsid` daemon and `iscsiadm` to be available to all nodes for the Kubernetes persistent volumes operations.
 * `siderolabs/util-linux-tools`: this extension enables linux tool to be available to all nodes. For example, the `fstrim` binary is used for {longhorn-product-name} volume trimming.
 
 The most straightforward method is patching the extensions onto existing Talos Linux nodes.
@@ -57,7 +57,8 @@ For detailed instructions, see the Talos documentation on https://www.talos.dev/
 
 To use V2 volumes, all nodes must meet the V2 Data Engine xref:longhorn-system/v2-data-engine/prerequisites.adoc[prerequisites].
 
-```yaml
+[,yaml]
+----
 machine:
   sysctls:
     vm.nr_hugepages: "1024"
@@ -66,13 +67,13 @@ machine:
       - name: nvme_tcp
       - name: vfio_pci
 #     - name: uio_pci_generic
-```
+----
 
 [NOTE]
 ====
-Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
+Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see https://spdk.io/doc/system_configuration.html[System Configuration User Guide] in the SPDK documentation.
 
-You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see [Issue #9236](https://github.com/siderolabs/talos/issues/9236).
+You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see https://github.com/siderolabs/talos/issues/9236[Issue #9236].
 ====
 
 == Talos Linux Upgrades
@@ -81,6 +82,7 @@ When https://www.talos.dev/v1.7/talos-guides/upgrading-talos/#talosctl-upgrade[u
 
 Example:
 
+[subs="+attributes",console]
 ----
 talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6 --preserve
 ----

--- a/docs/version-1.10/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
+++ b/docs/version-1.10/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
@@ -1,18 +1,20 @@
 = Create an Ingress with Basic Authentication (nginx)
 :current-version: {page-component-version}
 
-If you install Longhorn on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the Longhorn UI.
+If you install {longhorn-product-name} on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the {longhorn-product-name} UI.
 
 Authentication is not enabled by default for kubectl and Helm installations. In these steps, you'll learn how to create an Ingress with basic authentication using annotations for the nginx ingress controller.
 
 . Create a basic auth file `auth`. It's important the file generated is named auth (actually - that the secret has a key `data.auth`), otherwise the Ingress returns a 503.
 +
+[subs="+attributes",bash]
 ----
  $ USER=<USERNAME_HERE>; PASSWORD=<PASSWORD_HERE>; echo "${USER}:$(openssl passwd -stdin -apr1 <<< ${PASSWORD})" >> auth
 ----
 
 . Create a secret:
 +
+[subs="+attributes",bash]
 ----
  $ kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
 ----
@@ -20,9 +22,10 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
 . Create an Ingress manifest `longhorn-ingress.yml` :
 +
 ____
-Since v1.2.0, Longhorn supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
+Since v1.2.0, {longhorn-product-name} supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
 ____
 +
+[subs="+attributes",yaml]
 ----
  apiVersion: networking.k8s.io/v1
  kind: Ingress
@@ -56,12 +59,15 @@ ____
 
 . Create the Ingress:
 +
+[subs="+attributes",bash]
 ----
  $ kubectl -n longhorn-system apply -f longhorn-ingress.yml
 ----
 
-e.g.:
-```
+For example:
+
+[subs="+attributes",console]
+----
 $ USER=foo; PASSWORD=bar; echo "$\{USER}:$(openssl passwd -stdin -apr1 <<< $\{PASSWORD})" >> auth
 $ cat auth
 foo:$apr1$FnyKCYKb$6IP2C45fZxMcoLwkOwf7k0
@@ -136,4 +142,4 @@ Accept: _/_
 < Connection: keep-alive
 < WWW-Authenticate: Basic realm="Authentication Required"
 <
-```
+----

--- a/docs/version-1.10/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
+++ b/docs/version-1.10/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
@@ -11,7 +11,7 @@
 ARCH="amd64"
 
 # Download the release binary.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}"
 ----
 
 . Validate the binary:
@@ -19,7 +19,7 @@ curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version
 [subs="+attributes",bash]
 ----
 # Download the checksum for your architecture.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}.sha256"
 
 # Verify the downloaded binary matches the checksum.
 echo "$(cat longhornctl-linux-$\{ARCH}.sha256 | awk '{print $1}') longhornctl-linux-$\{ARCH}" | sha256sum --check

--- a/docs/version-1.10/modules/en/pages/longhorn-system/v2-data-engine/quick-start-guide.adoc
+++ b/docs/version-1.10/modules/en/pages/longhorn-system/v2-data-engine/quick-start-guide.adoc
@@ -189,7 +189,7 @@ Make sure everything is correctly configured and installed by
 
 [subs="+attributes", console]
 ----
-longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{{< current-version >}} install preflight --enable-spdk
+longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{patch-version} install preflight --enable-spdk
 ----
 
 Refer to xref:longhorn-system/system-access/longhorn-cli.adoc[Longhorn Command Line Tool] for more information.

--- a/docs/version-1.10/modules/en/pages/observability/configure-prometheus-grafana.adoc
+++ b/docs/version-1.10/modules/en/pages/observability/configure-prometheus-grafana.adoc
@@ -148,6 +148,7 @@ Save the above Alertmanager config in a file called `alertmanager.yaml` and crea
 +
 Alertmanager instances require the secret resource naming to follow the format `alertmanager-<ALERTMANAGER_NAME>`. In the previous step, the name of the Alertmanager is `longhorn`, so the secret name must be `alertmanager-longhorn`
 +
+[subs="+attributes",console]
 ----
  $ kubectl create secret generic alertmanager-longhorn --from-file=alertmanager.yaml -n default
 ----
@@ -433,6 +434,7 @@ ____
 
 . Access the Grafana dashboard using any node IP on port `32000`.
 +
+[subs="+attributes",bash]
 ----
  # Default Credential
  User: admin

--- a/docs/version-1.10/modules/en/pages/observability/configure-prometheus-grafana.adoc
+++ b/docs/version-1.10/modules/en/pages/observability/configure-prometheus-grafana.adoc
@@ -43,7 +43,8 @@ ____
 
 Create a ServiceMonitor for Longhorn Manager.
 
- ```yaml
+[,yaml]
+----
  apiVersion: monitoring.coreos.com/v1
  kind: ServiceMonitor
  metadata:
@@ -60,7 +61,7 @@ Create a ServiceMonitor for Longhorn Manager.
      - longhorn-system
    endpoints:
    - port: manager
- ```
+----
 
 ==== Install Longhorn ServiceMonitor with Helm
 
@@ -78,7 +79,7 @@ Create a ServiceMonitor for Longhorn Manager.
 +
 [subs="+attributes",bash]
 ----
-   helm upgrade longhorn longhorn/longhorn --namespace longhorn-system -f values.yaml
+  helm upgrade longhorn longhorn/longhorn --namespace longhorn-system -f values.yaml
 ----
 
 Longhorn ServiceMonitor is a https://prometheus-operator.dev/[Prometheus Operator] custom resource. This setup allows the Prometheus server to discover all Longhorn Manager pods and their respective endpoints.

--- a/docs/version-1.10/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
+++ b/docs/version-1.10/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
@@ -54,6 +54,7 @@ On Kubernetes clusters managed by Rancher 2.1 or newer, the steps to upgrade the
 
 To upgrade with kubectl, run this command:
 
+[subs="+attributes",shell]
 ----
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn.yaml
 ----
@@ -62,6 +63,7 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-ver
 
 To upgrade with Helm, run this command:
 
+[subs="+attributes",shell]
 ----
 helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version {patch-version}
 ----
@@ -70,10 +72,10 @@ Upgrade with Helm Controller
 
 Update the value of `spec.version` in the `HelmChart` YAML file:
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 spec:
-  version: v{{< current-version >}} # Replace with the version you would like to upgrade to
+  version: v{patch-version} # Replace with the version you would like to upgrade to
   chart: longhorn
   repo: https://charts.longhorn.io
   failurePolicy: abort
@@ -89,6 +91,7 @@ spec:
 
 and then apply it with
 
+[subs="+attributes",console]
 ----
 kubectl  patch helmchart longhorn -n <namespace> --type merge --patch-file <name of patch file>
 ----
@@ -102,6 +105,7 @@ In both cases, ensure that `spec.failurePolicy` is set to "abort".  The only oth
 
 Update the value of `helm.version` in the `fleet` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 helm:
   repo: https://charts.longhorn.io
@@ -114,6 +118,7 @@ helm:
 
 Update the value of `spec.chart.spec.version` in the `HelmRelease` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 spec:
   chart:
@@ -130,6 +135,7 @@ spec:
 
 Update the value of `targetRevision` in the `Application` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 spec:
   project: default
@@ -139,8 +145,10 @@ spec:
       targetRevision: v{patch-version} # Replace with the version you would like to upgrade to
 ----
 
-Then wait for all the pods to become running and Longhorn UI working. e.g.:
+Then wait for all the pods to become running and Longhorn UI working. For example:
 
+[subs="+attributes",yaml]
+----
  $ kubectl -n longhorn-system get pod
  NAME                                                  READY   STATUS    RESTARTS      AGE
  engine-image-ei-4dbdb778-nw88l                        1/1     Running   0             4m29s
@@ -162,6 +170,7 @@ Then wait for all the pods to become running and Longhorn UI working. e.g.:
  csi-resizer-6d8cf5f99f-7vv89                          1/1     Running   1 (30s ago)   37s
  csi-provisioner-869bdc4b79-sn6zr                      1/1     Running   1 (30s ago)   43s
  longhorn-csi-plugin-b2zzj                             2/2     Running   0             24s
+----
 
 Next, xref:upgrades/longhorn-components/manually-upgrade-engine.adoc[upgrade Longhorn engine.]
 
@@ -200,6 +209,7 @@ The `pre-upgrade` job blocks the upgrade process and provides the cause of the f
 
 Example:
 
+[subs="+attributes",shell]
 ----
 2m33s     Normal      Created                   Pod/longhorn-pre-upgrade-v5tqq     Created container longhorn-pre-upgrade
 2m33s     Warning     FailedUpgradePreCheck     /longhorn-pre-upgrade              failed to upgrade since upgrading from v1.6.2 to v1.8.0 for minor version is not supported
@@ -228,6 +238,7 @@ To recover, you need to upgrade to the previously installed revision at `Rancher
 
 * To clean up the deprecated StorageClass, run this command:
 +
+[subs="+attributes",console]
 ----
-  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
+kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
 ----

--- a/docs/version-1.10/modules/en/pages/volumes/volume-expansion.adoc
+++ b/docs/version-1.10/modules/en/pages/volumes/volume-expansion.adoc
@@ -28,6 +28,7 @@ This method is recommended if it's applicable, because the PVC and PV will be up
 
 Usage: Find the corresponding PVC for Longhorn volume, then modify the requested `spec.resources.requests.storage` of the PVC:
 
+[subs="+attributes",yaml]
 ----
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -120,10 +121,10 @@ Follow the steps below to resize the filesystem:
 
 Longhorn support for online expansion depends on Kubernetes.
 
-* Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
-* In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+* Kubernetes natively supports https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/[authenticated CSI storage resizing] starting in v1.29.
+* In https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/[Kubernetes v1.25 to v1.28], the feature gate `CSINodeExpandSecret` is required.
 
-You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+You can enable online expansion for encrypted volumes by specifying the following xref:volumes/volume-encryption.adoc#_setting_up_kubernetes_secrets_and_storageclasses[encryption parameters in the StorageClass]:
 
 * `csi.storage.k8s.io/node-expand-secret-name`
 * `csi.storage.k8s.io/node-expand-secret-namespace`

--- a/docs/version-1.10/modules/en/pages/volumes/volume-size.adoc
+++ b/docs/version-1.10/modules/en/pages/volumes/volume-size.adoc
@@ -10,7 +10,7 @@ This value, which you specified during volume creation, represents the amount of
 The following are other ways of understanding this concept:
 
 * The volume itself is just a Kubernetes CRD object and volume data is stored in replicas. This value represents the nominal size of each replica. 
-* Longhorn replicas use [sparse files](https://wiki.archlinux.org/index.php/Sparse_file) to store data. This value represents the maximum size to which a sparse file may expand.
+* Longhorn replicas use https://wiki.archlinux.org/index.php/Sparse_file[sparse files] to store data. This value represents the maximum size to which a sparse file may expand.
 
 Replicas are scheduled on nodes with enough allocatable space to cover this nominal size during volume creation. For more information, see xref:nodes/node-space-usage.adoc[Node Space Usage].
 
@@ -60,7 +60,7 @@ image::screenshots/volumes-and-nodes/volume-size-illustration-fig2.png[Image]
 . Then, rewrite the 4 Gi data (data#1), and the `df` command in the filesystem shows 4 Gi used space again. However, the `actual size` is increased by 4 Gi and becomes 8.25Gi. See Figure 3(a) of the illustration.
 +
 ____
-After deletion, filesystem may or maynot reuse the recently freed blocks from recently deleted files according to the filesystem design and please refer to https://www.ogris.de/blkalloc[Block allocation strategies of various filesystems]. If the volume nominal `size` is 12 Gi, the `actual size` in the end would range from 4 Gi to 8 Gi since the filesystem may or maynot reuse the freed blocks. On the other hand, if the volume nominal `size` is 6 Gi, the `actual size` at the end would range from 4 Gi to 6 Gi, because the filesystem has to reuse the freed blocks in the 2nd round of writing. See Figure 3(b) of the illustration.
+After deletion, filesystem may or may not reuse the recently freed blocks from recently deleted files according to the filesystem design and please refer to https://www.ogris.de/blkalloc[Block allocation strategies of various filesystems]. If the volume nominal `size` is 12 Gi, the `actual size` in the end would range from 4 Gi to 8 Gi since the filesystem may or may not reuse the freed blocks. On the other hand, if the volume nominal `size` is 6 Gi, the `actual size` at the end would range from 4 Gi to 6 Gi, because the filesystem has to reuse the freed blocks in the 2nd round of writing. See Figure 3(b) of the illustration.
 
 Thus, allocating an appropriate nominal `size` for a volume that holds heavy writing tasks according to the IO pattern would make disk space usage more efficient.
 ____

--- a/docs/version-1.7/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
+++ b/docs/version-1.7/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
@@ -1,39 +1,43 @@
 = Orphaned Data Cleanup
 :current-version: {page-component-version}
 
-Longhorn supports orphaned data cleanup. Currently, Longhorn can identify and clean up the orphaned replica directories on disks.
+{longhorn-product-name} supports orphaned data cleanup. Currently, {longhorn-product-name} can identify and clean up the orphaned replica directories on disks.
 
 == Orphaned Replica Directories
 
 When a user introduces a disk into a Longhorn node, it may contain replica directories that are not tracked by the Longhorn system. The untracked replica directories may belong to other Longhorn clusters. Or, the replica CRs associated with the replica directories are removed after the node or the disk is down. When the node or the disk comes back, the corresponding replica data directories are no longer tracked by the Longhorn system. These replica data directories are called orphaned.
 
-Longhorn supports the detection and cleanup of orphaned replica directories. It identifies the directories and gives a list of `orphan` resources that describe those directories. By default, Longhorn does not automatically delete `orphan` resources and their directories. Users can trigger the deletion of orphaned replica directories manually or have it done automatically.
+{longhorn-product-name} supports the detection and cleanup of orphaned replica directories. It identifies the directories and gives a list of `orphan` resources that describe those directories. By default, {longhorn-product-name} does not automatically delete `orphan` resources and their directories. Users can trigger the deletion of orphaned replica directories manually or have it done automatically.
 
 === Example
 
-In the example, we will explain how to manage orphaned replica directories identified by Longhorn via `kubectl` and Longhorn UI.
+In the example, we will explain how to manage orphaned replica directories identified by {longhorn-product-name} via `kubectl` and {longhorn-product-name} UI.
 
 ==== Manage Orphaned Replica Directories via kubectl
 
 . Introduce disks containing orphaned replica directories.
  ** Orphaned replica directories on Node `worker1` disks
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-15a210ed
 ----
 
  ** Orphaned replica directories on Node `worker2` disks
- ```
++
+[,console]
+----
  # ls /var/lib/longhorn/replicas/
  pvc-28255b31-161f-5621-eea3-a1cbafb4a12a-866aa0a5
 
-+
 # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-a86771c0
- ```
-. Longhorn detects the orphaned replica directories and creates an `orphan` resources describing the directories.
+----
+
+. {longhorn-product-name} detects the orphaned replica directories and creates an `orphan` resources describing the directories.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get orphans
  NAME                                                                      TYPE      NODE
@@ -44,12 +48,15 @@ In the example, we will explain how to manage orphaned replica directories ident
 
 . One can list the `orphan` resources created by Longhorn system by `kubectl -n longhorn-system get orphan`.
 +
+[,console]
 ----
  kubectl -n longhorn-system get orphan
 ----
 
-. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubcel -n longhorn-system get orphan <name>`.
-```
+. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubectl -n longhorn-system get orphan <name>`.
++
+[subs="+attributes",yaml]
+----
  # kubectl -n longhorn-system get orphans orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272 -o yaml
  apiVersion: longhorn.io/v1beta2
  kind: Orphan
@@ -64,9 +71,8 @@ In the example, we will explain how to manage orphaned replica directories ident
   longhorn.io/orphan-type: replica
   longhornnode: rancher60-worker1
 
-+
 ......
-+
+
 spec:
  nodeID: rancher60-worker1
  orphanType: replica
@@ -90,9 +96,11 @@ spec:
   status: "False"
   type: Error
  ownerID: rancher60-worker1
-```
+----
+
 . One can delete the `orphan` resource by `kubectl -n longhorn-system delete orphan <name>` and then the corresponding orphaned replica directory will be deleted.
 +
+[,console]
 ----
  # kubectl -n longhorn-system delete orphan orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272
 
@@ -104,18 +112,21 @@ spec:
 +
 The orphaned replica directory is deleted.
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
 ----
 
 . By default, Longhorn will not automatically delete the orphaned replica directory. One can enable the automatic deletion by setting `orphan-auto-deletion` to `true`.
 +
+[,console]
 ----
  # kubectl -n longhorn-system edit settings.longhorn.io orphan-auto-deletion
 ----
 +
 Then, set the value to `true`.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get settings.longhorn.io orphan-auto-deletion
  NAME                   VALUE   AGE
@@ -124,6 +135,7 @@ Then, set the value to `true`.
 
 . After enabling the automatic deletion and wait for a while, the `orphan` resources and directories are deleted automatically.
 +
+[,console]
 ----
  # kubectl -n longhorn-system get orphans.longhorn.io
  No resources found in longhorn-system namespace.
@@ -131,6 +143,7 @@ Then, set the value to `true`.
 +
 The orphaned replica directories are deleted.
 +
+[,console]
 ----
  # ls /mnt/disk/replicas/
 
@@ -139,19 +152,20 @@ The orphaned replica directories are deleted.
 +
 Additionally, one can delete all orphaned replica directories on the specified node by
 +
+[,console]
 ----
  # kubectl -n longhorn-system delete orphan -l "longhornnode=<node name>”
 ----
 
-==== Manage Orphaned Replica Directories via Longhorn UI
+==== Manage Orphaned Replica Directories via {longhorn-product-name} UI
 
-In the top navigation bar of the Longhorn UI, click `Setting > Orphaned Data`. Orphaned replica directories on each node and in each disk are listed. One can delete the directories by `Operation > Delete`.
+In the top navigation bar of the {longhorn-product-name} UI, click `Setting > Orphaned Data`. Orphaned replica directories on each node and in each disk are listed. One can delete the directories by `Operation > Delete`.
 
-By default, Longhorn will not automatically delete the orphaned replica directory. One can enable the automatic deletion in `Setting > General > Orphan`.
+By default, {longhorn-product-name} will not automatically delete the orphaned replica directory. One can enable the automatic deletion in `Setting > General > Orphan`.
 
 === Exception
 
-Longhorn will not create an `orphan` resource for an orphaned directory when
+{longhorn-product-name} will not create an `orphan` resource for an orphaned directory when
 
 * The orphaned directory is not an *orphaned replica directory*.
  ** The directory name does not follow the replica directory's naming convention.

--- a/docs/version-1.7/modules/en/pages/installation-setup/installation/install-using-flux.adoc
+++ b/docs/version-1.7/modules/en/pages/installation-setup/installation/install-using-flux.adoc
@@ -99,10 +99,11 @@ Example of a successful installation:
 
 You can commit and push exported manifests to your GitOps repository.
 
- ```bash
- git add helmrepo.yaml helmrelease.yaml
- git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
- git push origin <branch_name>
- ```
+[subs="+attributes",bash]
+----
+git add helmrepo.yaml helmrelease.yaml
+git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
+git push origin <branch_name>
+----
 
 Afterwards, you can modify the HelmRelease and HelmRepository CRs by editing the YAML manifests in your GitOps repository. Flux automatically detects and applies the changes without requiring direct access to your Kubernetes cluster.

--- a/docs/version-1.7/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.7/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -13,13 +13,13 @@ Use https://github.com/longhorn/longhorn/blob/v{patch-version}/scripts/environme
 
 [NOTE]
 ====
-* The initial settings can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
+* The initial settings can be xref:longhorn-system/customize-default-settings.adoc#_using_helm[customized using Helm options or by editing the deployment configuration file].
 * For Kubernetes v1.25 or earlier, if your cluster still enables Pod Security Policy admission controller, set the helm value `enablePSP` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
 ====
 
 . Create a HelmChart yaml file similar to the following:
 +
-[,yaml]
+[subs="+attributes",yaml]
 ----
 apiVersion: helm.cattle.io/v1
   kind: HelmChart
@@ -32,7 +32,7 @@ apiVersion: helm.cattle.io/v1
     name: longhorn-install
     namespace: default
   spec:
-    version: v{{< current-version >}}
+    version: v{patch-version}
     chart: longhorn
     repo: https://charts.longhorn.io
     failurePolicy: abort
@@ -45,11 +45,13 @@ apiVersion: helm.cattle.io/v1
 * Ensure that `spec.failurePolicy` is set to "abort".  The only other value is the default: "reinstall", which uninstalls {longhorn-product-name}.  With "abort", it retries periodically, giving the user a chance to fix the problem.
 +
 * Rather than specify the repo, version, and chart name, the yaml can also use an image of the charts themselves:
++
 [,yaml]
 ----
 spec:
   chartContent:  <tarball of chart directory | base64 -w 0>
 ----
++
 For full details see the HelmChart controller docs: https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html[{rke2-product-name} - Helm] or https://documentation.suse.com/cloudnative/k3s/latest/en/helm.html[{k3s-product-name} - Helm].
 ====
 +
@@ -67,7 +69,7 @@ Deleting the helmchart CR will initiate uninstallation of {longhorn-product-name
 ====
 . Check the created resources.
 +
-[,shell]
+[subs="+attributes",shell]
 ----
 $ kubectl get jobs
 NAME                            COMPLETIONS   DURATION   AGE
@@ -77,7 +79,7 @@ NAME                                  READY   STATUS      RESTARTS   AGE
 helm-install-longhorn-install-lngm8   0/1     Completed   0          25s
 $ kubectl get helmcharts
 NAME               JOB                     CHART      TARGETNAMESPACE   VERSION   REPO                         HELMVERSION   BOOTSTRAP
-longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{{< current-version >}}    https://charts.longhorn.io
+longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{patch-version}    https://charts.longhorn.io
 ----
 +
 . Verify that the deployment succeeded.

--- a/docs/version-1.7/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
+++ b/docs/version-1.7/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
@@ -154,7 +154,10 @@ oc annotate node ${NODE_NAME} --overwrite node.longhorn.io/default-disks-config=
 oc label node ${NODE_NAME} --overwrite node.longhorn.io/create-default-disk=config
 ----
 
-NOTE: You might need to reboot the node to validate the modified configuration.
+[NOTE]
+====
+You might need to reboot the node to validate the modified configuration.
+====
 
 == Reference
 

--- a/docs/version-1.7/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.7/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -65,6 +65,7 @@ When https://www.talos.dev/v1.7/talos-guides/upgrading-talos/#talosctl-upgrade[u
 
 Example:
 
+[subs="+attributes",console]
 ----
 talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6 --preserve
 ----

--- a/docs/version-1.7/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
+++ b/docs/version-1.7/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
@@ -1,18 +1,20 @@
 = Create an Ingress with Basic Authentication (nginx)
 :current-version: {page-component-version}
 
-If you install Longhorn on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the Longhorn UI.
+If you install {longhorn-product-name} on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the {longhorn-product-name} UI.
 
 Authentication is not enabled by default for kubectl and Helm installations. In these steps, you'll learn how to create an Ingress with basic authentication using annotations for the nginx ingress controller.
 
 . Create a basic auth file `auth`. It's important the file generated is named auth (actually - that the secret has a key `data.auth`), otherwise the Ingress returns a 503.
 +
+[subs="+attributes",console]
 ----
  $ USER=<USERNAME_HERE>; PASSWORD=<PASSWORD_HERE>; echo "${USER}:$(openssl passwd -stdin -apr1 <<< ${PASSWORD})" >> auth
 ----
 
 . Create a secret:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
 ----
@@ -20,9 +22,10 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
 . Create an Ingress manifest `longhorn-ingress.yml` :
 +
 ____
-Since v1.2.0, Longhorn supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
+Since v1.2.0, {longhorn-product-name} supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
 ____
 +
+[subs="+attributes",console]
 ----
  apiVersion: networking.k8s.io/v1
  kind: Ingress
@@ -55,12 +58,15 @@ ____
 
 . Create the Ingress:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system apply -f longhorn-ingress.yml
 ----
 
-e.g.:
-```
+For example:
+
+[subs="+attributes",console]
+----
 $ USER=foo; PASSWORD=bar; echo "$\{USER}:$(openssl passwd -stdin -apr1 <<< $\{PASSWORD})" >> auth
 $ cat auth
 foo:$apr1$FnyKCYKb$6IP2C45fZxMcoLwkOwf7k0
@@ -135,4 +141,4 @@ Accept: _/_
 < Connection: keep-alive
 < WWW-Authenticate: Basic realm="Authentication Required"
 <
-```
+----

--- a/docs/version-1.7/modules/en/pages/observability/configure-prometheus-grafana.adoc
+++ b/docs/version-1.7/modules/en/pages/observability/configure-prometheus-grafana.adoc
@@ -43,7 +43,8 @@ ____
 
 Create a ServiceMonitor for Longhorn Manager.
 
- ```yaml
+[,yaml]
+----
  apiVersion: monitoring.coreos.com/v1
  kind: ServiceMonitor
  metadata:
@@ -60,7 +61,7 @@ Create a ServiceMonitor for Longhorn Manager.
      - longhorn-system
    endpoints:
    - port: manager
- ```
+----
 
 ==== Install Longhorn ServiceMonitor with Helm
 

--- a/docs/version-1.7/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
+++ b/docs/version-1.7/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
@@ -57,6 +57,7 @@ On Kubernetes clusters managed by Rancher 2.1 or newer, the steps to upgrade the
 
 Run the following command:
 
+[subs="+attributes",shell]
 ----
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn.yaml
 ----
@@ -65,6 +66,7 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-ver
 
 Run the following command:
 
+[subs="+attributes",shell]
 ----
 helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version {patch-version}
 ----
@@ -73,7 +75,7 @@ helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version {p
 
 Update the value of `spec.version` in the `HelmChart` YAML file.
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 spec:
   version: v{patch-version} # Replace with the version you would like to upgrade to
@@ -85,6 +87,7 @@ spec:
 Alternatively, if you are using the `spec.chartContent` key, create and apply a patch file.
 
 * Create the file:
++
 [,yaml]
 ----
 spec:
@@ -92,6 +95,8 @@ spec:
 ----
 
 * Apply the file.
++
+[subs="+attributes",shell]
 ----
 kubectl  patch helmchart longhorn -n <namespace> --type merge --patch-file <name of patch file>
 ----
@@ -105,7 +110,7 @@ In both cases, ensure that `spec.failurePolicy` is set to `abort` so that {longh
 
 Update the value of `helm.version` in the `fleet` YAML file of your GitOps repository.
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 helm:
   repo: https://charts.longhorn.io
@@ -118,7 +123,7 @@ helm:
 
 Update the value of `spec.chart.spec.version` in the `HelmRelease` YAML file of your GitOps repository.
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 spec:
   chart:
@@ -135,7 +140,7 @@ spec:
 
 Update the value of `targetRevision` in the `Application` YAML file of your GitOps repository.
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 spec:
   project: default
@@ -145,9 +150,9 @@ spec:
       targetRevision: v{patch-version} # Replace with the version you would like to upgrade to
 ----
 
-Then wait for all the pods to become running and {longhorn-product-name} UI working.
+Then wait for all the pods to become running and {longhorn-product-name} UI working. For example:
 
-Example:
+[subs="+attributes",shell]
 ----
  $ kubectl -n longhorn-system get pod
  NAME                                                  READY   STATUS    RESTARTS      AGE
@@ -237,6 +242,7 @@ To recover, you need to upgrade to the previously installed revision at `Rancher
 
 * To clean up the deprecated StorageClass, run this command:
 +
+[subs="+attributes",console]
 ----
-  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
+kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
 ----

--- a/docs/version-1.8/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
+++ b/docs/version-1.8/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
@@ -1,39 +1,43 @@
 = Orphaned Data Cleanup
 :current-version: {page-component-version}
 
-Longhorn supports orphaned data cleanup. Currently, Longhorn can identify and clean up the orphaned replica directories on disks.
+{longhorn-product-name} supports orphaned data cleanup. Currently, {longhorn-product-name} can identify and clean up the orphaned replica directories on disks.
 
 == Orphaned Replica Directories
 
 When a user introduces a disk into a Longhorn node, it may contain replica directories that are not tracked by the Longhorn system. The untracked replica directories may belong to other Longhorn clusters. Or, the replica CRs associated with the replica directories are removed after the node or the disk is down. When the node or the disk comes back, the corresponding replica data directories are no longer tracked by the Longhorn system. These replica data directories are called orphaned.
 
-Longhorn supports the detection and cleanup of orphaned replica directories. It identifies the directories and gives a list of `orphan` resources that describe those directories. By default, Longhorn does not automatically delete `orphan` resources and their directories. Users can trigger the deletion of orphaned replica directories manually or have it done automatically.
+{longhorn-product-name} supports the detection and cleanup of orphaned replica directories. It identifies the directories and gives a list of `orphan` resources that describe those directories. By default, {longhorn-product-name} does not automatically delete `orphan` resources and their directories. Users can trigger the deletion of orphaned replica directories manually or have it done automatically.
 
 === Example
 
-In the example, we will explain how to manage orphaned replica directories identified by Longhorn via `kubectl` and Longhorn UI.
+In the example, we will explain how to manage orphaned replica directories identified by {longhorn-product-name} via `kubectl` and {longhorn-product-name} UI.
 
 ==== Manage Orphaned Replica Directories via kubectl
 
 . Introduce disks containing orphaned replica directories.
  ** Orphaned replica directories on Node `worker1` disks
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-15a210ed
 ----
 
  ** Orphaned replica directories on Node `worker2` disks
- ```
++
+[subs="+attributes",console]
+----
  # ls /var/lib/longhorn/replicas/
  pvc-28255b31-161f-5621-eea3-a1cbafb4a12a-866aa0a5
 
-+
 # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-a86771c0
- ```
-. Longhorn detects the orphaned replica directories and creates an `orphan` resources describing the directories.
+----
+
+. {longhorn-product-name} detects the orphaned replica directories and creates an `orphan` resources describing the directories.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get orphans
  NAME                                                                      TYPE      NODE
@@ -44,12 +48,15 @@ In the example, we will explain how to manage orphaned replica directories ident
 
 . One can list the `orphan` resources created by Longhorn system by `kubectl -n longhorn-system get orphan`.
 +
+[subs="+attributes",console]
 ----
  kubectl -n longhorn-system get orphan
 ----
 
-. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubcel -n longhorn-system get orphan <name>`.
-```
+. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubectl -n longhorn-system get orphan <name>`.
++
+[subs="+attributes",yaml]
+----
  # kubectl -n longhorn-system get orphans orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272 -o yaml
  apiVersion: longhorn.io/v1beta2
  kind: Orphan
@@ -64,9 +71,8 @@ In the example, we will explain how to manage orphaned replica directories ident
   longhorn.io/orphan-type: replica
   longhornnode: rancher60-worker1
 
-+
 ......
-+
+
 spec:
  nodeID: rancher60-worker1
  orphanType: replica
@@ -90,9 +96,11 @@ spec:
   status: "False"
   type: Error
  ownerID: rancher60-worker1
-```
+----
+
 . One can delete the `orphan` resource by `kubectl -n longhorn-system delete orphan <name>` and then the corresponding orphaned replica directory will be deleted.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system delete orphan orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272
 
@@ -104,18 +112,21 @@ spec:
 +
 The orphaned replica directory is deleted.
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
 ----
 
-. By default, Longhorn will not automatically delete the orphaned replica directory. One can enable the automatic deletion by setting `orphan-auto-deletion` to `true`.
+. By default, {longhorn-product-name} will not automatically delete the orphaned replica directory. One can enable the automatic deletion by setting `orphan-auto-deletion` to `true`.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system edit settings.longhorn.io orphan-auto-deletion
 ----
 +
 Then, set the value to `true`.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get settings.longhorn.io orphan-auto-deletion
  NAME                   VALUE   AGE
@@ -124,6 +135,7 @@ Then, set the value to `true`.
 
 . After enabling the automatic deletion and wait for a while, the `orphan` resources and directories are deleted automatically.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get orphans.longhorn.io
  No resources found in longhorn-system namespace.
@@ -131,6 +143,7 @@ Then, set the value to `true`.
 +
 The orphaned replica directories are deleted.
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
 
@@ -139,19 +152,20 @@ The orphaned replica directories are deleted.
 +
 Additionally, one can delete all orphaned replica directories on the specified node by
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system delete orphan -l "longhornnode=<node name>”
 ----
 
-==== Manage Orphaned Replica Directories via Longhorn UI
+==== Manage Orphaned Replica Directories via {longhorn-product-name} UI
 
-In the top navigation bar of the Longhorn UI, click `Setting > Orphaned Data`. Orphaned replica directories on each node and in each disk are listed. One can delete the directories by `Operation > Delete`.
+In the top navigation bar of the {longhorn-product-name} UI, click `Setting > Orphaned Data`. Orphaned replica directories on each node and in each disk are listed. One can delete the directories by `Operation > Delete`.
 
-By default, Longhorn will not automatically delete the orphaned replica directory. One can enable the automatic deletion in `Setting > General > Orphan`.
+By default, {longhorn-product-name} will not automatically delete the orphaned replica directory. One can enable the automatic deletion in `Setting > General > Orphan`.
 
 === Exception
 
-Longhorn will not create an `orphan` resource for an orphaned directory when
+{longhorn-product-name} will not create an `orphan` resource for an orphaned directory when
 
 * The orphaned directory is not an *orphaned replica directory*.
  ** The directory name does not follow the replica directory's naming convention.

--- a/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-flux.adoc
+++ b/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-flux.adoc
@@ -99,10 +99,11 @@ Example of a successful installation:
 
 You can commit and push exported manifests to your GitOps repository.
 
- ```bash
- git add helmrepo.yaml helmrelease.yaml
- git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
- git push origin <branch_name>
- ```
+[subs="+attributes",console]
+----
+git add helmrepo.yaml helmrelease.yaml
+git commit -m "Add HelmRepository and HelmRelease for Longhorn installation"
+git push origin <branch_name>
+----
 
 Afterwards, you can modify the HelmRelease and HelmRepository CRs by editing the YAML manifests in your GitOps repository. Flux automatically detects and applies the changes without requiring direct access to your Kubernetes cluster.

--- a/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -19,7 +19,7 @@ Use https://github.com/longhorn/longhorn/blob/v{patch-version}/scripts/environme
 
 . Create a HelmChart YAML file similar to the following:
 +
-[,yaml]
+[subs="+attributes",yaml]
 ----
 apiVersion: helm.cattle.io/v1
   kind: HelmChart
@@ -32,7 +32,7 @@ apiVersion: helm.cattle.io/v1
     name: longhorn-install
     namespace: default
   spec:
-    version: v{{< current-version >}}
+    version: v{patch-version}
     chart: longhorn
     repo: https://charts.longhorn.io
     failurePolicy: abort
@@ -45,11 +45,13 @@ apiVersion: helm.cattle.io/v1
 * Ensure that `spec.failurePolicy` is set to "abort".  The only other value is the default: "reinstall", which uninstalls {longhorn-product-name}.  With "abort", it retries periodically, giving the user a chance to fix the problem.
 +
 * Rather than specify the repo, version, and chart name, the yaml can also use an image of the charts themselves:
++
 [,yaml]
 ----
 spec:
   chartContent:  <tarball of chart directory | base64 -w 0>
 ----
++
 For full details see the HelmChart controller docs: https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html[{rke2-product-name} - Helm] or https://documentation.suse.com/cloudnative/k3s/latest/en/helm.html[{k3s-product-name} - Helm].
 ====
 +
@@ -67,7 +69,7 @@ Deleting the HelmChart CR initiates uninstallation of {longhorn-product-name}.
 ====
 . Check the created resources.
 +
-[,shell]
+[subs="+attributes",console]
 ----
 $ kubectl get jobs
 NAME                            COMPLETIONS   DURATION   AGE
@@ -77,7 +79,7 @@ NAME                                  READY   STATUS      RESTARTS   AGE
 helm-install-longhorn-install-lngm8   0/1     Completed   0          25s
 $ kubectl get helmcharts
 NAME               JOB                     CHART      TARGETNAMESPACE   VERSION   REPO                         HELMVERSION   BOOTSTRAP
-longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{{< current-version >}}    https://charts.longhorn.io
+longhorn-install   helm-install-longhorn   longhorn   longhorn-system   v{patch-version}    https://charts.longhorn.io
 ----
 +
 . Verify that the deployment succeeded.

--- a/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
+++ b/docs/version-1.8/modules/en/pages/installation-setup/installation/install-using-helm-controller.adoc
@@ -13,7 +13,7 @@ Use https://github.com/longhorn/longhorn/blob/v{patch-version}/scripts/environme
 
 [NOTE]
 ====
-* The initial settings can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
+* The initial settings can be xref:longhorn-system/customize-default-settings.adoc#_using_helm[customized using Helm options or by editing the deployment configuration file].
 * For Kubernetes v1.25 or earlier, if your cluster still enables Pod Security Policy admission controller, set the helm value `enablePSP` to `true` to install `longhorn-psp` PodSecurityPolicy resource which allows privileged Longhorn pods to start.
 ====
 

--- a/docs/version-1.8/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
+++ b/docs/version-1.8/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
@@ -41,12 +41,13 @@ helm install longhorn longhorn/longhorn \
 
 === Install With `oc` Command
 
-Perform the following steps to install Longhorn on [OKD](https://www.okd.io/) clusters.
+Perform the following steps to install Longhorn on https://www.okd.io/[OKD] clusters.
 
 . Download the `longhorn-okd.yaml` file.
 +
+[subs="+attributes",console]
 ----
-wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-okd.yaml
+wget https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn-okd.yaml
 ----
 +
 . Specify the target `oauth-proxy` container image in the `longhorn-okd.yaml` file (for example, `quay.io/openshift/origin-oauth-proxy:4.15`).
@@ -150,7 +151,10 @@ oc annotate node ${NODE_NAME} --overwrite node.longhorn.io/default-disks-config=
 oc label node ${NODE_NAME} --overwrite node.longhorn.io/create-default-disk=config
 ----
 
-NOTE: You might need to reboot the node to validate the modified configuration.
+[NOTE]
+====
+You might need to reboot the node to validate the modified configuration.
+====
 
 == Reference
 

--- a/docs/version-1.8/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.8/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -9,7 +9,7 @@ You must meet the following requirements before installing {longhorn-product-nam
 
 Some {longhorn-product-name}-dependent binary executables are not present in the default Talos root filesystem. To have access to these binaries, Talos offers system extension mechanism to extend the installation.
 
-* `siderolabs/iscsi-tools`: this extension enables iscsid daemon and iscsiadm to be available to all nodes for the Kubernetes persistent volumes operations.
+* `siderolabs/iscsi-tools`: this extension enables `iscsid` daemon and `iscsiadm` to be available to all nodes for the Kubernetes persistent volumes operations.
 * `siderolabs/util-linux-tools`: this extension enables linux tool to be available to all nodes. For example, the `fstrim` binary is used for {longhorn-product-name} volume trimming.
 
 The most straightforward method is patching the extensions onto existing Talos Linux nodes.
@@ -57,7 +57,8 @@ For detailed instructions, see the Talos documentation on https://www.talos.dev/
 
 To use V2 volumes, all nodes must meet the V2 Data Engine xref:longhorn-system/v2-data-engine/prerequisites.adoc[prerequisites].
 
-```yaml
+[subs="+attributes",yaml]
+----
 machine:
   sysctls:
     vm.nr_hugepages: "1024"
@@ -66,13 +67,13 @@ machine:
       - name: nvme_tcp
       - name: vfio_pci
 #     - name: uio_pci_generic
-```
+----
 
 [NOTE]
 ====
-Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
+Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see https://spdk.io/doc/system_configuration.html[System Configuration User Guide] in the SPDK documentation.
 
-You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see [Issue #9236](https://github.com/siderolabs/talos/issues/9236).
+You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see https://github.com/siderolabs/talos/issues/9236[Issue #9236].
 ====
 
 == Talos Linux Upgrades
@@ -81,6 +82,7 @@ When https://www.talos.dev/v1.7/talos-guides/upgrading-talos/#talosctl-upgrade[u
 
 Example:
 
+[subs="+attributes",console]
 ----
 talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6 --preserve
 ----

--- a/docs/version-1.8/modules/en/pages/longhorn-system/settings.adoc
+++ b/docs/version-1.8/modules/en/pages/longhorn-system/settings.adoc
@@ -171,7 +171,7 @@ Upgrade Checker will check for a new {longhorn-product-name} version periodicall
 
 === Upgrade Responder URL
 
-*Default value*: `https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade`
+*Default value*: `pass:[https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade]`
 
 The Upgrade Responder sends a notification whenever a new {longhorn-product-name} version that you can upgrade to becomes available.
 

--- a/docs/version-1.8/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
+++ b/docs/version-1.8/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
@@ -1,18 +1,20 @@
 = Create an Ingress with Basic Authentication (nginx)
 :current-version: {page-component-version}
 
-If you install Longhorn on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the Longhorn UI.
+If you install {longhorn-product-name} on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the {longhorn-product-name} UI.
 
 Authentication is not enabled by default for kubectl and Helm installations. In these steps, you'll learn how to create an Ingress with basic authentication using annotations for the nginx ingress controller.
 
 . Create a basic auth file `auth`. It's important the file generated is named auth (actually - that the secret has a key `data.auth`), otherwise the Ingress returns a 503.
 +
+[subs="+attributes",console]
 ----
  $ USER=<USERNAME_HERE>; PASSWORD=<PASSWORD_HERE>; echo "${USER}:$(openssl passwd -stdin -apr1 <<< ${PASSWORD})" >> auth
 ----
 
 . Create a secret:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
 ----
@@ -20,9 +22,10 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
 . Create an Ingress manifest `longhorn-ingress.yml` :
 +
 ____
-Since v1.2.0, Longhorn supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
+Since v1.2.0, {longhorn-product-name} supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
 ____
 +
+[subs="+attributes",console]
 ----
  apiVersion: networking.k8s.io/v1
  kind: Ingress
@@ -56,12 +59,15 @@ ____
 
 . Create the Ingress:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system apply -f longhorn-ingress.yml
 ----
 
-e.g.:
-```
+For example:
+
+[subs="+attributes",yaml]
+----
 $ USER=foo; PASSWORD=bar; echo "$\{USER}:$(openssl passwd -stdin -apr1 <<< $\{PASSWORD})" >> auth
 $ cat auth
 foo:$apr1$FnyKCYKb$6IP2C45fZxMcoLwkOwf7k0
@@ -136,4 +142,4 @@ Accept: _/_
 < Connection: keep-alive
 < WWW-Authenticate: Basic realm="Authentication Required"
 <
-```
+----

--- a/docs/version-1.8/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
+++ b/docs/version-1.8/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
@@ -11,7 +11,7 @@
 ARCH="amd64"
 
 # Download the release binary.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}"
 ----
 
 . Validate the binary:
@@ -19,7 +19,7 @@ curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version
 [subs="+attributes",bash]
 ----
 # Download the checksum for your architecture.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}.sha256"
 
 # Verify the downloaded binary matches the checksum.
 echo "$(cat longhornctl-linux-$\{ARCH}.sha256 | awk '{print $1}') longhornctl-linux-$\{ARCH}" | sha256sum --check

--- a/docs/version-1.8/modules/en/pages/observability/configure-prometheus-grafana.adoc
+++ b/docs/version-1.8/modules/en/pages/observability/configure-prometheus-grafana.adoc
@@ -43,7 +43,8 @@ ____
 
 Create a ServiceMonitor for Longhorn Manager.
 
- ```yaml
+[,yaml]
+----
  apiVersion: monitoring.coreos.com/v1
  kind: ServiceMonitor
  metadata:
@@ -60,7 +61,7 @@ Create a ServiceMonitor for Longhorn Manager.
      - longhorn-system
    endpoints:
    - port: manager
- ```
+----
 
 ==== Install Longhorn ServiceMonitor with Helm
 

--- a/docs/version-1.8/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
+++ b/docs/version-1.8/modules/en/pages/upgrades/longhorn-components/upgrade-longhorn-manager.adoc
@@ -54,6 +54,7 @@ On Kubernetes clusters managed by Rancher 2.1 or newer, the steps to upgrade the
 
 To upgrade with kubectl, run this command:
 
+[subs="+attributes",shell]
 ----
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn.yaml
 ----
@@ -62,6 +63,7 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-ver
 
 To upgrade with Helm, run this command:
 
+[subs="+attributes",shell]
 ----
 helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version {patch-version}
 ----
@@ -70,7 +72,7 @@ Upgrade with Helm Controller
 
 Update the value of `spec.version` in the `HelmChart` YAML file:
 
-[,yaml]
+[subs="+attributes",yaml]
 ----
 spec:
   version: v{patch-version} # Replace with the version you would like to upgrade to
@@ -89,6 +91,7 @@ spec:
 
 and then apply it with
 
+[subs="+attributes",shell]
 ----
 kubectl  patch helmchart longhorn -n <namespace> --type merge --patch-file <name of patch file>
 ----
@@ -102,6 +105,7 @@ In both cases, ensure that `spec.failurePolicy` is set to "abort".  The only oth
 
 Update the value of `helm.version` in the `fleet` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 helm:
   repo: https://charts.longhorn.io
@@ -114,6 +118,7 @@ helm:
 
 Update the value of `spec.chart.spec.version` in the `HelmRelease` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 spec:
   chart:
@@ -130,6 +135,7 @@ spec:
 
 Update the value of `targetRevision` in the `Application` YAML file of your GitOps repository.
 
+[subs="+attributes",yaml]
 ----
 spec:
   project: default
@@ -139,8 +145,9 @@ spec:
       targetRevision: v{patch-version} # Replace with the version you would like to upgrade to
 ----
 
-Then wait for all the pods to become running and Longhorn UI working. e.g.:
-
+Then wait for all the pods to become running and Longhorn UI working. For example:
+[subs="+attributes",console]
+----
  $ kubectl -n longhorn-system get pod
  NAME                                                  READY   STATUS    RESTARTS      AGE
  engine-image-ei-4dbdb778-nw88l                        1/1     Running   0             4m29s
@@ -162,6 +169,7 @@ Then wait for all the pods to become running and Longhorn UI working. e.g.:
  csi-resizer-6d8cf5f99f-7vv89                          1/1     Running   1 (30s ago)   37s
  csi-provisioner-869bdc4b79-sn6zr                      1/1     Running   1 (30s ago)   43s
  longhorn-csi-plugin-b2zzj                             2/2     Running   0             24s
+----
 
 Next, xref:upgrades/longhorn-components/manually-upgrade-engine.adoc[upgrade Longhorn engine.]
 
@@ -200,6 +208,7 @@ The `pre-upgrade` job blocks the upgrade process and provides the cause of the f
 
 Example:
 
+[subs="+attributes",console]
 ----
 2m33s     Normal      Created                   Pod/longhorn-pre-upgrade-v5tqq     Created container longhorn-pre-upgrade
 2m33s     Warning     FailedUpgradePreCheck     /longhorn-pre-upgrade              failed to upgrade since upgrading from v1.6.2 to v1.8.0 for minor version is not supported
@@ -228,6 +237,7 @@ To recover, you need to upgrade to the previously installed revision at `Rancher
 
 * To clean up the deprecated StorageClass, run this command:
 +
+[subs="+attributes",console]
 ----
-  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
+kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/examples/storageclass.yaml
 ----

--- a/docs/version-1.8/modules/en/pages/volumes/volume-expansion.adoc
+++ b/docs/version-1.8/modules/en/pages/volumes/volume-expansion.adoc
@@ -28,6 +28,7 @@ This method is recommended if it's applicable, because the PVC and PV will be up
 
 Usage: Find the corresponding PVC for Longhorn volume, then modify the requested `spec.resources.requests.storage` of the PVC:
 
+[subs="+attributes",yaml]
 ----
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -120,10 +121,10 @@ Follow the steps below to resize the filesystem:
 
 Longhorn support for online expansion depends on Kubernetes.
 
-* Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
-* In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+* Kubernetes natively supports https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/[authenticated CSI storage resizing] starting in v1.29.
+* In https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/[Kubernetes v1.25 to v1.28], the feature gate `CSINodeExpandSecret` is required.
 
-You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+You can enable online expansion for encrypted volumes by specifying the following xref:volumes/volume-encryption.adoc#_setting_up_kubernetes_secrets_and_storageclasses[encryption parameters in the StorageClass]:
 
 * `csi.storage.k8s.io/node-expand-secret-name`
 * `csi.storage.k8s.io/node-expand-secret-namespace`

--- a/docs/version-1.9/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
+++ b/docs/version-1.9/modules/en/pages/data-integrity-recovery/orphaned-data-cleanup.adoc
@@ -20,6 +20,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 . Introduce disks containing orphaned replica directories.
  ** Orphaned replica directories on Node `worker1` disks
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
  pvc-19c45b11-28ee-4802-bea4-c0cabfb3b94c-15a210ed
@@ -27,6 +28,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 
  ** Orphaned replica directories on Node `worker2` disks
 +
+[subs="+attributes",console]
 ----
 # ls /var/lib/longhorn/replicas/
  pvc-28255b31-161f-5621-eea3-a1cbafb4a12a-866aa0a5
@@ -37,6 +39,7 @@ The following example demonstrate how to manage orphaned replica directories ide
 
 . {longhorn-product-name} detects the orphaned replica directories and creates an `orphan` resources describing the directories.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get orphans -l "longhorn.io/orphan-type=replica"
  NAME                                                                      TYPE      NODE
@@ -47,12 +50,15 @@ The following example demonstrate how to manage orphaned replica directories ide
 
 . Retrieve a list of orphaned resources created by {longhorn-product-name} using the command `kubectl -n longhorn-system get orphan`.
 +
+[subs="+attributes",console]
 ----
  kubectl -n longhorn-system get orphan
 ----
 
-. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubcel -n longhorn-system get orphan <name>`.
-```
+. Get the detailed information of one of the orphaned replica directories in `spec.parameters` by `kubectl -n longhorn-system get orphan <name>`.
++
+[subs="+attributes",yaml]
+----
  # kubectl -n longhorn-system get orphans orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272 -o yaml
  apiVersion: longhorn.io/v1beta2
  kind: Orphan
@@ -67,9 +73,8 @@ The following example demonstrate how to manage orphaned replica directories ide
   longhorn.io/orphan-type: replica
   longhornnode: rancher60-worker1
 
-+
 ......
-+
+
 spec:
  nodeID: rancher60-worker1
  orphanType: replica
@@ -93,9 +98,11 @@ spec:
   status: "False"
   type: Error
  ownerID: rancher60-worker1
-```
+----
+
 . One can delete the `orphan` resource by `kubectl -n longhorn-system delete orphan <name>` and then the corresponding orphaned replica directory will be deleted.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system delete orphan orphan-fed8c6c20965c7bdc3e3bbea5813fac52ccd6edcbf31e578f2d8bab93481c272
 
@@ -107,18 +114,21 @@ spec:
 +
 The orphaned replica directory is deleted.
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
 ----
 
 . By default, {longhorn-product-name} will not automatically delete the orphaned replica directory. You can enable automatic deletion by setting the `orphan-resource-auto-deletion` setting.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system edit settings.longhorn.io orphan-resource-auto-deletion
 ----
 +
 Then, add `replica-data` to the list by including it as one of the semicolon-separated items.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get settings.longhorn.io orphan-resource-auto-deletion
  NAME                           VALUE          APPLIED     AGE
@@ -127,6 +137,7 @@ Then, add `replica-data` to the list by including it as one of the semicolon-sep
 
 . After enabling the automatic deletion and wait for a while, the `orphan` resources and directories are deleted automatically.
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system get orphans.longhorn.io -l "longhorn.io/orphan-type=replica"
  No resources found in longhorn-system namespace.
@@ -134,6 +145,7 @@ Then, add `replica-data` to the list by including it as one of the semicolon-sep
 +
 The orphaned replica directories are deleted.
 +
+[subs="+attributes",console]
 ----
  # ls /mnt/disk/replicas/
 
@@ -142,6 +154,7 @@ The orphaned replica directories are deleted.
 +
 Additionally, one can delete all orphaned replica directories on the specified node by
 +
+[subs="+attributes",console]
 ----
  # kubectl -n longhorn-system delete orphan -l "longhorn.io/orphan-type=replica-instance,longhornnode=<node name>”
 ----

--- a/docs/version-1.9/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
+++ b/docs/version-1.9/modules/en/pages/installation-setup/os-distro/ocp-okd.adoc
@@ -41,12 +41,13 @@ helm install longhorn longhorn/longhorn \
 
 === Install With `oc` Command
 
-Perform the following steps to install Longhorn on [OKD](https://www.okd.io/) clusters.
+Perform the following steps to install Longhorn on https://www.okd.io/[OKD] clusters.
 
 . Download the `longhorn-okd.yaml` file.
 +
+[subs="+attributes",bash]
 ----
-wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-okd.yaml
+wget https://raw.githubusercontent.com/longhorn/longhorn/v{patch-version}/deploy/longhorn-okd.yaml
 ----
 +
 . Specify the target `oauth-proxy` container image in the `longhorn-okd.yaml` file (for example, `quay.io/openshift/origin-oauth-proxy:4.18`).
@@ -150,7 +151,10 @@ oc annotate node ${NODE_NAME} --overwrite node.longhorn.io/default-disks-config=
 oc label node ${NODE_NAME} --overwrite node.longhorn.io/create-default-disk=config
 ----
 
-NOTE: You might need to reboot the node to validate the modified configuration.
+[NOTE]
+====
+You might need to reboot the node to validate the modified configuration.
+====
 
 == Reference
 

--- a/docs/version-1.9/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
+++ b/docs/version-1.9/modules/en/pages/installation-setup/os-distro/talos-linux.adoc
@@ -9,7 +9,7 @@ You must meet the following requirements before installing {longhorn-product-nam
 
 Some {longhorn-product-name}-dependent binary executables are not present in the default Talos root filesystem. To have access to these binaries, Talos offers system extension mechanism to extend the installation.
 
-* `siderolabs/iscsi-tools`: this extension enables iscsid daemon and iscsiadm to be available to all nodes for the Kubernetes persistent volumes operations.
+* `siderolabs/iscsi-tools`: this extension enables `iscsid` daemon and `iscsiadm` to be available to all nodes for the Kubernetes persistent volumes operations.
 * `siderolabs/util-linux-tools`: this extension enables linux tool to be available to all nodes. For example, the `fstrim` binary is used for {longhorn-product-name} volume trimming.
 
 The most straightforward method is patching the extensions onto existing Talos Linux nodes.
@@ -57,7 +57,8 @@ For detailed instructions, see the Talos documentation on https://www.talos.dev/
 
 To use V2 volumes, all nodes must meet the V2 Data Engine xref:longhorn-system/v2-data-engine/prerequisites.adoc[prerequisites].
 
-```yaml
+[subs="+attributes",yaml]
+----
 machine:
   sysctls:
     vm.nr_hugepages: "1024"
@@ -66,13 +67,13 @@ machine:
       - name: nvme_tcp
       - name: vfio_pci
 #     - name: uio_pci_generic
-```
+----
 
 [NOTE]
 ====
-Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
+Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If your system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, you are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see https://spdk.io/doc/system_configuration.html[System Configuration User Guide] in the SPDK documentation.
 
-You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see [Issue #9236](https://github.com/siderolabs/talos/issues/9236).
+You can use `uio_pci_generic` if `vfio_pci` is incompatible with your system or specific hardware. Future versions of Talos Linux are expected to include native support for `uio_pci_generic`. For more information, see https://github.com/siderolabs/talos/issues/9236[Issue #9236].
 ====
 
 == Talos Linux Upgrades
@@ -81,6 +82,7 @@ When https://www.talos.dev/v1.7/talos-guides/upgrading-talos/#talosctl-upgrade[u
 
 Example:
 
+[subs="+attributes",console]
 ----
 talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6 --preserve
 ----

--- a/docs/version-1.9/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
+++ b/docs/version-1.9/modules/en/pages/longhorn-system/system-access/create-ingress.adoc
@@ -1,18 +1,20 @@
 = Create an Ingress with Basic Authentication (nginx)
 :current-version: {page-component-version}
 
-If you install Longhorn on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the Longhorn UI.
+If you install {longhorn-product-name} on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the {longhorn-product-name} UI.
 
 Authentication is not enabled by default for kubectl and Helm installations. In these steps, you'll learn how to create an Ingress with basic authentication using annotations for the nginx ingress controller.
 
 . Create a basic auth file `auth`. It's important the file generated is named auth (actually - that the secret has a key `data.auth`), otherwise the Ingress returns a 503.
 +
+[subs="+attributes",console]
 ----
  $ USER=<USERNAME_HERE>; PASSWORD=<PASSWORD_HERE>; echo "${USER}:$(openssl passwd -stdin -apr1 <<< ${PASSWORD})" >> auth
 ----
 
 . Create a secret:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
 ----
@@ -20,9 +22,10 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
 . Create an Ingress manifest `longhorn-ingress.yml` :
 +
 ____
-Since v1.2.0, Longhorn supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
+Since v1.2.0, {longhorn-product-name} supports uploading backing image from the UI, so please specify `nginx.ingress.kubernetes.io/proxy-body-size: 10000m` as below to ensure uploading images work as expected.
 ____
 +
+[subs="+attributes",yaml]
 ----
  apiVersion: networking.k8s.io/v1
  kind: Ingress
@@ -56,12 +59,15 @@ ____
 
 . Create the Ingress:
 +
+[subs="+attributes",console]
 ----
  $ kubectl -n longhorn-system apply -f longhorn-ingress.yml
 ----
 
-e.g.:
-```
+For example:
+
+[subs="+attributes",yaml]
+----
 $ USER=foo; PASSWORD=bar; echo "$\{USER}:$(openssl passwd -stdin -apr1 <<< $\{PASSWORD})" >> auth
 $ cat auth
 foo:$apr1$FnyKCYKb$6IP2C45fZxMcoLwkOwf7k0
@@ -136,4 +142,4 @@ Accept: _/_
 < Connection: keep-alive
 < WWW-Authenticate: Basic realm="Authentication Required"
 <
-```
+----

--- a/docs/version-1.9/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
+++ b/docs/version-1.9/modules/en/pages/longhorn-system/system-access/install-longhorn-cli.adoc
@@ -11,7 +11,7 @@
 ARCH="amd64"
 
 # Download the release binary.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}"
 ----
 
 . Validate the binary:
@@ -19,7 +19,7 @@ curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version
 [subs="+attributes",bash]
 ----
 # Download the checksum for your architecture.
-curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+curl -LO "https://github.com/longhorn/cli/releases/download/v{patch-version}/longhornctl-linux-${ARCH}.sha256"
 
 # Verify the downloaded binary matches the checksum.
 echo "$(cat longhornctl-linux-$\{ARCH}.sha256 | awk '{print $1}') longhornctl-linux-$\{ARCH}" | sha256sum --check

--- a/docs/version-1.9/modules/en/pages/longhorn-system/v2-data-engine/quick-start-guide.adoc
+++ b/docs/version-1.9/modules/en/pages/longhorn-system/v2-data-engine/quick-start-guide.adoc
@@ -187,9 +187,9 @@ worker1:
 
 Make sure everything is correctly configured and installed by
 
-[subs="+attributes", console]
+[subs="+attributes",console]
 ----
-longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{{< current-version >}} install preflight --enable-spdk
+longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{patch-version} install preflight --enable-spdk
 ----
 
 Refer to xref:longhorn-system/system-access/longhorn-cli.adoc[Longhorn Command Line Tool] for more information.
@@ -210,6 +210,7 @@ Or, you can enable it in `Setting > General > V2 Data Engine`.
 
 When the V2 Data Engine is enabled, each Instance Manager pod for the V2 Data Engine uses 1 CPU core. The high CPU usage is caused by `spdk_tgt`, a process running in each Instance Manager pod that handles input/output (IO) operations and requires intensive polling. `spdk_tgt` consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations.
 
+[subs="+attributes",console]
 ----
 NAME                                                CPU(cores)   MEMORY(bytes)
 csi-attacher-57c5fd5bdf-jsfs4                       1m           7Mi
@@ -236,6 +237,7 @@ longhorn-ui-58db78b68-ffbxr                         0m           2Mi
 
 You can observe the utilization of allocated huge pages on each node by running the command `kubectl get node <node name> -o yaml`.
 
+[subs="+attributes",console]
 ----
 # kubectl get node sles-pool1-07437316-4jw8f -o yaml
 ...

--- a/docs/version-1.9/modules/en/pages/observability/configure-prometheus-grafana.adoc
+++ b/docs/version-1.9/modules/en/pages/observability/configure-prometheus-grafana.adoc
@@ -43,7 +43,8 @@ ____
 
 Create a ServiceMonitor for Longhorn Manager.
 
- ```yaml
+[,yaml]
+----
  apiVersion: monitoring.coreos.com/v1
  kind: ServiceMonitor
  metadata:
@@ -60,7 +61,7 @@ Create a ServiceMonitor for Longhorn Manager.
      - longhorn-system
    endpoints:
    - port: manager
- ```
+----
 
 ==== Install Longhorn ServiceMonitor with Helm
 

--- a/docs/version-1.9/modules/en/pages/volumes/volume-expansion.adoc
+++ b/docs/version-1.9/modules/en/pages/volumes/volume-expansion.adoc
@@ -120,10 +120,10 @@ Follow the steps below to resize the filesystem:
 
 Longhorn support for online expansion depends on Kubernetes.
 
-* Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
-* In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+* Kubernetes natively supports https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/[authenticated CSI storage resizing] starting in v1.29.
+* In https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/[Kubernetes v1.25 to v1.28], the feature gate `CSINodeExpandSecret` is required.
 
-You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+You can enable online expansion for encrypted volumes by specifying the following xref:volumes/volume-encryption.adoc#_setting_up_kubernetes_secrets_and_storageclasses[encryption parameters in the StorageClass]:
 
 * `csi.storage.k8s.io/node-expand-secret-name`
 * `csi.storage.k8s.io/node-expand-secret-namespace`

--- a/docs/version-1.9/modules/en/pages/volumes/volume-size.adoc
+++ b/docs/version-1.9/modules/en/pages/volumes/volume-size.adoc
@@ -10,7 +10,7 @@ This value, which you specified during volume creation, represents the amount of
 The following are other ways of understanding this concept:
 
 * The volume itself is just a Kubernetes CRD object and volume data is stored in replicas. This value represents the nominal size of each replica. 
-* Longhorn replicas use [sparse files](https://wiki.archlinux.org/index.php/Sparse_file) to store data. This value represents the maximum size to which a sparse file may expand.
+* Longhorn replicas use https://wiki.archlinux.org/index.php/Sparse_file[sparse files] to store data. This value represents the maximum size to which a sparse file may expand.
 
 Replicas are scheduled on nodes with enough allocatable space to cover this nominal size during volume creation. For more information, see xref:nodes/node-space-usage.adoc[Node Space Usage].
 


### PR DESCRIPTION
What I have done in this PR:
- replaced `current-version` variable with `patch-version` variable.
- fixed all incorrect links with correct path.
- fixed incorrect way of adding links in adoc files.
- added `[subs="+attributes",` to codes that has variables for correct rendering.
- fixed other minor issues of incorrect numbering.