### PR TITLE
Use shared resource for attributes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "dsc-style-bundle"]
 	path = dsc-style-bundle
 	url = git@github.com:SUSEdoc/dsc-style-bundle.git
+[submodule "product-docs-common"]
+	path = product-docs-common
+	url = https://github.com/rancher/product-docs-common

--- a/lh-local-playbook.yml
+++ b/lh-local-playbook.yml
@@ -23,6 +23,9 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+    attributefile: ./product-docs-common/global-attributes.yml
+    enabled: true
 
 output:
   dir: build/site

--- a/lh-remote-playbook.yml
+++ b/lh-remote-playbook.yml
@@ -23,6 +23,9 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+    attributefile: ./product-docs-common/global-attributes.yml
+    enabled: true
 
 output:
   dir: build/site


### PR DESCRIPTION
Currently if #277 is merged, builds using playbooks without the `page-project-data` attribute defined will fail with the error below. This PR enables access to the attribute globally.

```
FATAL (antora): Cannot read properties of undefined (reading 'find') in UI template partials/breadcrumbs.hbs
    Cause: Error
    d')
```