### PR TITLE
docs: fix broken api links from k8s

### DIFF
--- a/docs/version-1.11/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.11/modules/en/pages/important-notes.adoc
@@ -1,5 +1,5 @@
 = Important Notes
-:revdate: 2026-05-06
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :current-version: {page-component-version}
 
@@ -82,7 +82,7 @@ For more details, see xref:longhorn-system/settings.adoc#_manager_url[Manager UR
 
 === Gateway API HTTPRoute Support
 
-{longhorn-product-name} v{patch-version} introduces built-in support for https://gateway-api.sigs.k8s.io/api-types/httproute[Gateway API HTTPRoute] as a modern alternative to Ingress for exposing the {longhorn-product-name} UI.
+{longhorn-product-name} v{patch-version} introduces built-in support for https://gateway-api.sigs.k8s.io/reference/api-types/httproute[Gateway API HTTPRoute] as a modern alternative to Ingress for exposing the {longhorn-product-name} UI.
 
 For detailed setup instructions, prerequisites and advanced configuration, see xref:longhorn-system/system-access/longhorn-httproute.adoc[Create an HTTPRoute with Gateway API].
 

--- a/docs/version-1.11/modules/en/pages/longhorn-system/system-access/longhorn-httproute.adoc
+++ b/docs/version-1.11/modules/en/pages/longhorn-system/system-access/longhorn-httproute.adoc
@@ -1,5 +1,5 @@
 = Create an HTTPRoute with Gateway API
-:revdate: 2025-12-22
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :current-version: {page-component-version}
 
@@ -137,4 +137,4 @@ The output should show `Accepted: True` and `ResolvedRefs: True`.
 == References
 
 * https://gateway-api.sigs.k8s.io/[Gateway API documentation]
-* https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute[HTTPRoute specification]
+* https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gateway.networking.k8s.io/v1.HTTPRoute[HTTPRoute specification]

--- a/docs/version-1.12/modules/en/pages/important-notes.adoc
+++ b/docs/version-1.12/modules/en/pages/important-notes.adoc
@@ -1,5 +1,5 @@
 = Important Notes
-:revdate: 2026-05-06
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :current-version: {page-component-version}
 
@@ -87,7 +87,7 @@ For more details, see xref:longhorn-system/settings.adoc#_manager_url[Manager UR
 
 === Gateway API HTTPRoute Support
 
-{longhorn-product-name} v{patch-version} introduces built-in support for https://gateway-api.sigs.k8s.io/api-types/httproute[Gateway API HTTPRoute] as a modern alternative to Ingress for exposing the {longhorn-product-name} UI.
+{longhorn-product-name} v{patch-version} introduces built-in support for https://gateway-api.sigs.k8s.io/reference/api-types/httproute[Gateway API HTTPRoute] as a modern alternative to Ingress for exposing the {longhorn-product-name} UI.
 
 For detailed setup instructions, prerequisites and advanced configuration, see xref:longhorn-system/system-access/longhorn-httproute.adoc[Create an HTTPRoute with Gateway API].
 

--- a/docs/version-1.12/modules/en/pages/longhorn-system/system-access/longhorn-httproute.adoc
+++ b/docs/version-1.12/modules/en/pages/longhorn-system/system-access/longhorn-httproute.adoc
@@ -1,5 +1,5 @@
 = Create an HTTPRoute with Gateway API
-:revdate: 2025-12-22
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :current-version: {page-component-version}
 
@@ -137,4 +137,4 @@ The output should show `Accepted: True` and `ResolvedRefs: True`.
 == References
 
 * https://gateway-api.sigs.k8s.io/[Gateway API documentation]
-* https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute[HTTPRoute specification]
+* https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gateway.networking.k8s.io/v1.HTTPRoute[HTTPRoute specification]


### PR DESCRIPTION
Links of k8s documentation has changed. So updated the links on our docs.