### PR TITLE
Add release notes for v1.9.1, v1.9.2, v1.10.1, v1.10.2, v1.11.1, v1.11.2, v1.11.3

### DIFF
--- a/docs/version-1.10/modules/en/nav.adoc
+++ b/docs/version-1.10/modules/en/nav.adoc
@@ -1,9 +1,21 @@
+// SUSE Storage Documentation Section:
 * xref:longhorn-documentation.adoc[]
+
+// Release Notes Section:
+* Release Notes
+** xref:release-notes/v1.10.1.adoc[]
+** xref:release-notes/v1.10.2.adoc[]
+
+// Introduction Section:
 * xref:introduction/introduction.adoc[]
 ** xref:introduction/concepts.adoc[]
 ** xref:introduction/terminology.adoc[]
 ** xref:introduction/document-conventions.adoc[]
+
+// Important Notes Section:
 * xref:important-notes.adoc[]
+
+// Installation and Setup Section:
 * Installation and Setup
 ** xref:installation-setup/requirements.adoc[]
 ** xref:installation-setup/best-practices.adoc[]
@@ -22,6 +34,8 @@
 *** xref:installation-setup/os-distro/k3s.adoc[]
 ** xref:installation-setup/setup-performance-scalability-sizing-guidelines.adoc[]
 ** xref:installation-setup/uninstallation.adoc[]
+
+// Upgrades Section:
 * xref:upgrades/upgrades.adoc[]
 ** Component Upgrades
 *** xref:upgrades/longhorn-components/auto-upgrade-engine.adoc[]
@@ -32,8 +46,12 @@
 *** xref:upgrades/kubernetes/upgrade-k8s-on-aks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-eks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-gke.adoc[]
+
+// Migration Section:
 * Migration
 ** xref:migration/migration.adoc[]
+
+// SUSE Storage System Section:
 * SUSE® Storage System
 ** xref:longhorn-system/system-access/system-access.adoc[]
 *** xref:longhorn-system/system-access/longhorn-ui.adoc[]
@@ -62,6 +80,8 @@
 *** xref:longhorn-system/v2-data-engine/performance.adoc[]
 ** xref:longhorn-system/examples-resources.adoc[]
 ** xref:longhorn-system/migrate-flexvolume.adoc[]
+
+// Nodes Section:
 * Nodes
 ** xref:nodes/node-space-usage.adoc[]
 ** xref:nodes/default-disk-and-node-config.adoc[]
@@ -77,6 +97,8 @@
 *** xref:nodes/managed-kubernetes/aks-managed-node-groups.adoc[]
 *** xref:nodes/managed-kubernetes/eks-managed-node-pools.adoc[]
 *** xref:nodes/managed-kubernetes/gke-managed-node-pools.adoc[]
+
+// Volumes Section:
 * Volumes
 ** xref:volumes/create-volumes.adoc[]
 ** xref:volumes/pvc-ownership-and-permission.adoc[]
@@ -95,6 +117,8 @@
 ** xref:volumes/storageclass-parameters.adoc[]
 ** xref:volumes/backing-images/backing-images.adoc[]
 *** xref:volumes/backing-images/backing-image-encryption.adoc[]
+
+// High Availability Section:
 * High Availability
 ** xref:high-availability/automatic-replica-balancing.adoc[]
 ** xref:high-availability/replica-rebuilding.adoc[]
@@ -106,6 +130,8 @@
 ** xref:high-availability/rwx-volume-fast-failover.adoc[]
 ** xref:high-availability/volume-recovery.adoc[]
 ** xref:high-availability/node-failure.adoc[]
+
+// Snapshots and Backups Section:
 * Snapshots and Backups
 ** xref:snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.adoc[]
 *** xref:snapshots-backups/volume-snapshots-backups/create-snapshot.adoc[]
@@ -129,6 +155,8 @@
 *** xref:snapshots-backups/system-backups/restore-system.adoc[]
 ** xref:snapshots-backups/backing-image-backups.adoc[]
 ** xref:snapshots-backups/restore-cluster-rancher-snapshot.adoc[]
+
+// Data Integrity and Recovery Section:
 * Data Integrity and Recovery
 ** xref:data-integrity-recovery/snapshot-data-integrity-check.adoc[]
 ** xref:data-integrity-recovery/orphaned-data-cleanup.adoc[]
@@ -140,16 +168,22 @@
 *** xref:data-integrity-recovery/data-recovery/recover-from-data-errors.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-from-full-disk.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-without-system.adoc[]
+
+// Observability Section:
 * Observability
 ** xref:observability/configure-prometheus-grafana.adoc[]
 ** xref:observability/alert-rule-examples.adoc[]
 ** xref:observability/longhorn-metrics.adoc[]
 ** xref:observability/integrate-with-rancher-monitoring.adoc[]
 ** xref:observability/kubelet-volume-metrics.adoc[]
+
+// Troubleshooting and Maintenance Section:
 * Troubleshooting and Maintenance
 ** xref:troubleshooting-maintenance/support-bundle.adoc[]
 ** xref:troubleshooting-maintenance/troubleshooting.adoc[]
 ** xref:troubleshooting-maintenance/v2-data-engine-issues.adoc[]
 ** xref:troubleshooting-maintenance/maintenance.adoc[]
+
+// Glossary Section:
 * Glossary
 ** xref:glossary/glossary.adoc[]

--- a/docs/version-1.10/modules/en/pages/release-notes/v1.10.1.adoc
+++ b/docs/version-1.10/modules/en/pages/release-notes/v1.10.1.adoc
@@ -1,0 +1,209 @@
+= {longhorn-product-name} v1.10.1 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This is a major release focused on improving stability, performance and the overall user experience. This version introduces significant enhancements to our core features, including the V2 Data Engine, and streamlines configuration for easier management. The key highlights include improvements to the V2 Data Engine, enhanced resilience, simplified configuration, and better observability. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For more information about release-related terminology, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Removals
+
+=== `longhorn.io/v1beta1` API
+
+The `v1beta1` {longhorn-product-name} API version has been removed.
+
+See https://github.com/longhorn/longhorn/issues/10249[#10249] for details.
+
+=== `replica.status.evictionRequested` field
+
+The deprecated `replica.status.evictionRequested` field has been removed.
+
+See https://github.com/longhorn/longhorn/issues/7022[#7022] for details.
+
+== Primary highlights
+
+=== New V2 Data Engine features
+
+==== Interrupt mode support
+
+Interrupt mode has been added to the V2 Data Engine to help reduce CPU usage. This feature is especially beneficial for clusters with idle or low I/O workloads, where conserving CPU resources is more important than minimizing latency.
+
+While interrupt mode lowers CPU consumption, it may introduce slightly higher I/O latency compared to polling mode. Besides the current implementation uses a hybrid approach, which still incurs a minimal, constant CPU load even when interrupts are enabled.
+
+[NOTE]
+====
+*Limitation*: Supports *AIO disks only*.
+====
+
+See xref:v2-data-engine/features/interrupt-mode.adoc[Interrupt Mode] and https://github.com/longhorn/longhorn/issues/9834[issue #9834] for details.
+
+==== Volume and snapshot cloning
+
+V2 volumes now support two types of cloning:
+
+* *Full-Copy Clone*: Creates a new PVC with a complete, independent copy of the source data, providing full isolation.
+* *Linked-Clone (Fast/Smart Clone)*: Creates a PVC that shares data blocks with the source volume for near-instant creation. Ideal for temporary workloads, backups, or testing. Linked-clones are lightweight, fast, and reduce storage overhead.
+
+See xref:v2-data-engine/features/volume-clone.adoc[Volume Clone Support] and https://github.com/longhorn/longhorn/issues/7794[#7794] for details.
+
+==== Replica rebuild QoS
+
+Provides Quality of Service (QoS) control for V2 volume replica rebuilds. You can configure bandwidth limits globally or per volume to prevent storage throughput overload on source and destination nodes.
+
+See xref:v2-data-engine/features/replica-rebuild-qos.adoc[Replica Rebuild QoS] and https://github.com/longhorn/longhorn/issues/10770[#10770] for details.
+
+==== Volume expansion
+
+{longhorn-product-name} now supports volume expansion for V2 Data Engine volumes. You can expand the volume through the UI or by modifying the PVC manifest.
+
+See xref:v2-data-engine/features/volume-expansion.adoc[V2 Volume Expansion] and https://github.com/longhorn/longhorn/issues/8022[#8022] for details.
+
+==== Support for running without Hugepages
+
+This reduces memory pressure on low-spec nodes and increases deployment flexibility. Performance may be lower compared to running with Hugepages.
+
+See https://github.com/longhorn/longhorn/issues/7066[#7066] for details.
+
+=== New V1 Data Engine features
+
+==== IPv6 support
+
+V1 volumes now support single-stack IPv6 Kubernetes clusters.
+
+[WARNING]
+====
+Dual-stack Kubernetes clusters and V2 volumes are *not supported* in this release.
+====
+
+See https://github.com/longhorn/longhorn/issues/2259[#2259] for details.
+
+=== Consolidated global settings
+
+To simplify management, {longhorn-product-name} settings are now unified across V1 and V2 Data Engines, using a new, more flexible JSON format.
+
+* *Single value (applies to all Data Engines)*: Non-JSON string (for example, `1024`).
+* *Data-engine-specific*: JSON object (for example, `{"v1": "value1", "v2": "value2"}`)
+* *V1-only*: JSON object with v1 key (for example, `{"v1":"value1"}`).
+* *V2-only*: JSON object with v2 key (for example, `{"v2":"value1"}`).
+
+See xref:references/settings.adoc[{longhorn-product-name} Settings] and https://github.com/longhorn/longhorn/issues/10926[issue #10926] for details.
+
+=== Pod scheduling with CSIStorageCapacity
+
+{longhorn-product-name} now supports *CSIStorageCapacity*, allowing Kubernetes to verify node storage before scheduling pods using StorageClasses with *WaitForFirstConsumer*. This reduces scheduling errors and improves reliability.
+
+See https://github.com/longhorn/longhorn/issues/10685[#10685] for details.
+
+=== Configurable backup block size
+
+Backup block size can now be configured when creating a volume to optimize performance and efficiency.
+
+See xref:nodes-and-volumes/volumes/create-volumes.adoc[Create {longhorn-product-name} Volumes] and https://github.com/longhorn/longhorn/issues/5215[#5215] for details.
+
+=== Volume attachment summary
+
+The UI now shows a summary of attachment tickets on each volume page for improved visibility.
+
+See https://github.com/longhorn/longhorn/issues/11400[#11400] for details.
+
+== Important fixes
+
+This release includes several critical stability and performance improvements:
+
+=== Goroutine leak in instance manager (V2 Data Engine)
+
+Fixed a goroutine leak in the instance manager when using the V2 data engine. This issue could lead to increased memory usage and potential stability problems over time.
+
+For more details, see https://github.com/longhorn/longhorn/issues/11962[#11962].
+
+=== V2 volume attachment failure in interrupt mode
+
+Fixed an issue where V2 volumes using interrupt mode with NVMe disks could fail to complete the attachment process, causing volumes to remain stuck in the attaching state indefinitely.
+
+In v1.10.0, interrupt mode supports only *AIO disks*. Interrupt mode for *NVMe disks* is supported starting in v1.10.1.
+
+For more details, see https://github.com/longhorn/longhorn/issues/11816[#11816].
+
+=== UI deployment failure on IPv4-only nodes
+
+Fixed a bug introduced in v1.10.0 where the UI failed to deploy on nodes with only IPv4 enabled. The UI now correctly supports IPv4-only configurations without requiring IPv6.
+
+For more details, see https://github.com/longhorn/longhorn/issues/11875[#11875].
+
+=== Share manager excessive memory usage
+
+Fixed excessive memory consumption in the share manager for RWX (ReadWriteMany) volumes. The component now maintains stable memory usage under normal operation.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12043[#12043].
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.1.*
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.1.*
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release known issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved issues
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/12125[#12125] [BACKPORT][v1.10.1][IMPROVEMENT] The `auto-delete-pod-when-volume-detached-unexpectedly` should only focus on the kubernetes builtin workload.
+* https://github.com/longhorn/longhorn/issues/12036[#12036] [BACKPORT][v1.10.1][IMPROVEMENT] `CSIStorageCapacity` objects must show schedulable (allocatable) capacity
+* https://github.com/longhorn/longhorn/issues/12033[#12033] [BACKPORT][v1.10.1][IMPROVEMENT] improve error logging for failed mounting during node publish volume
+* https://github.com/longhorn/longhorn/issues/12020[#12020] [BACKPORT][v1.10.1][IMPROVEMENT] Improve Helm Chart defaultSettings handling with automatic quoting and multi-type support
+* https://github.com/longhorn/longhorn/issues/11945[#11945] [BACKPORT][v1.10.1][IMPROVEMENT] Avoid repeat engine restart when there are replica unavailable during migration
+* https://github.com/longhorn/longhorn/issues/11968[#11968] [BACKPORT][v1.10.1][IMPROVEMENT] Adjust maximum of GuaranteedInstanceManagerCPU to a big value
+* https://github.com/longhorn/longhorn/issues/11795[#11795] [BACKPORT][v1.10.1][IMPROVEMENT] Add usage metrics for Longhorn installation variant
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/12089[#12089] [BACKPORT][v1.10.1][BUG] Backup target metric is broken
+* https://github.com/longhorn/longhorn/issues/12094[#12094] [BACKPORT][v1.10.1][BUG] Backing image download gets stuck after network disconnection
+* https://github.com/longhorn/longhorn/issues/12088[#12088] [BACKPORT][v1.10.1][BUG] panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 at longhorn-engine/pkg/controller/control.go:218 +0x2de]
+* https://github.com/longhorn/longhorn/issues/11964[#11964] [BACKPORT][v1.10.1][BUG] Unable to complete uninstallation due to the remaining backuptarget
+* https://github.com/longhorn/longhorn/issues/12043[#12043] [BACKPORT][v1.10.1][BUG] share-manager excessive memory usage
+* https://github.com/longhorn/longhorn/issues/12029[#12029] [BACKPORT][v1.10.1][BUG] NVME disk not found in v2 data engine (failed to find device for BDF)
+* https://github.com/longhorn/longhorn/issues/11926[#11926] [BACKPORT][v1.10.1][BUG] NPE error during recurring job execution
+* https://github.com/longhorn/longhorn/issues/12026[#12026] [BACKPORT][v1.10.1][BUG] v2 volume creation failed on talos nodes
+* https://github.com/longhorn/longhorn/issues/12008[#12008] [BACKPORT][v1.10.1][BUG] mounting error is not properly hanedled during CSI node publish volume
+* https://github.com/longhorn/longhorn/issues/12018[#12018] [BACKPORT][v1.10.1][BUG] Adding multiple disks to the same node concurrently may occasionally fail
+* https://github.com/longhorn/longhorn/issues/11886[#11886] [BUG] upgrading from 1.9.1 to 1.10.0 fails due to old resources still being in v1beta1
+* https://github.com/longhorn/longhorn/issues/11998[#11998] [BACKPORT][v1.10.1][BUG] DR volume gets stuck in `unknown` state if engine image is deleted from the attached node
+* https://github.com/longhorn/longhorn/issues/11996[#11996] [BACKPORT][v1.10.1][BUG] Volume gets stuck in `attaching` state if engine image is not deployed on one of nodes
+* https://github.com/longhorn/longhorn/issues/12000[#12000] [BACKPORT][v1.10.1][BUG] Unable to re-add block-type disks by BDF after re-enable v2 data engine
+* https://github.com/longhorn/longhorn/issues/12005[#12005] [BACKPORT][v1.10.1][BUG] `test_system_backup_and_restore` test case failed on master-head
+* https://github.com/longhorn/longhorn/issues/11970[#11970] [BACKPORT][v1.10.1][BUG] Fix SPDK v25.05 CVE issue
+* https://github.com/longhorn/longhorn/issues/11976[#11976] [BACKPORT][v1.10.1][BUG] V2 volume stuck in volume attachment (V2 interrupt mode)
+* https://github.com/longhorn/longhorn/issues/11958[#11958] [BACKPORT][v1.10.1][BUG] RWX volume causes process uninterruptible sleep
+* https://github.com/longhorn/longhorn/issues/11865[#11865] [BACKPORT][v1.10.1][BUG] longhorn-manager fails to start after upgrading from 1.9.2 to 1.10.0
+* https://github.com/longhorn/longhorn/issues/11954[#11954] [BACKPORT][v1.10.1][BUG] Block disk deletion fails without error message
+* https://github.com/longhorn/longhorn/issues/11962[#11962] [BACKPORT][v1.10.1][BUG] Goroutine leak in instance-manager when using v2 data engine
+* https://github.com/longhorn/longhorn/issues/11942[#11942] [BACKPORT][v1.10.1][BUG] invalid memory address or nil pointer dereference
+* https://github.com/longhorn/longhorn/issues/11918[#11918] [BACKPORT][v1.10.1][BUG] csi-provisioner silently fails to create CSIStorageCapacity if dataEngine parameter is missing
+* https://github.com/longhorn/longhorn/issues/11901[#11901] [BACKPORT][v1.10.1][BUG] longhorn-engine's UI panics
+* https://github.com/longhorn/longhorn/issues/11895[#11895] [BACKPORT][v1.10.1][BUG] Volume is unable to upgrade if the number of active replicas is larger than `volumme.spec.numberOfReplicas`
+* https://github.com/longhorn/longhorn/issues/11875[#11875] [BACKPORT][v1.10.1][BUG] UI fails to deploy when only IPv4 is enabled on nodes with v1.10.0 version
+* https://github.com/longhorn/longhorn/issues/11801[#11801] [BACKPORT][v1.10.1][BUG] Unable to detach a v2 volume after labeling `disable-v2-data-engine=true`
+
+=== Misc
+
+* https://github.com/longhorn/longhorn/issues/11992[#11992] [BACKPORT][v1.10.1][REFACTOR] SAST checks for UI component
+* https://github.com/longhorn/longhorn/issues/11951[#11951] [HOTFIX] Create hotfixed image for longhorn-manager:v1.10.0

--- a/docs/version-1.10/modules/en/pages/release-notes/v1.10.1.adoc
+++ b/docs/version-1.10/modules/en/pages/release-notes/v1.10.1.adoc
@@ -23,7 +23,7 @@ The deprecated `replica.status.evictionRequested` field has been removed.
 
 See https://github.com/longhorn/longhorn/issues/7022[#7022] for details.
 
-== Primary highlights
+== Primary Highlights
 
 === New V2 Data Engine features
 
@@ -38,7 +38,7 @@ While interrupt mode lowers CPU consumption, it may introduce slightly higher I/
 *Limitation*: Supports *AIO disks only*.
 ====
 
-See xref:v2-data-engine/features/interrupt-mode.adoc[Interrupt Mode] and https://github.com/longhorn/longhorn/issues/9834[issue #9834] for details.
+See xref:v2-data-engine/features/interrupt-mode.adoc[Interrupt Mode] and https://github.com/longhorn/longhorn/issues/9834[#9834] for details.
 
 ==== Volume and snapshot cloning
 
@@ -89,7 +89,7 @@ To simplify management, {longhorn-product-name} settings are now unified across 
 * *V1-only*: JSON object with v1 key (for example, `{"v1":"value1"}`).
 * *V2-only*: JSON object with v2 key (for example, `{"v2":"value1"}`).
 
-See xref:references/settings.adoc[{longhorn-product-name} Settings] and https://github.com/longhorn/longhorn/issues/10926[issue #10926] for details.
+See xref:references/settings.adoc[{longhorn-product-name} Settings] and https://github.com/longhorn/longhorn/issues/10926[#10926] for details.
 
 === Pod scheduling with CSIStorageCapacity
 
@@ -143,7 +143,7 @@ For more details, see https://github.com/longhorn/longhorn/issues/12043[#12043].
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.1.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.1*.
 ====
 
 You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
@@ -152,58 +152,58 @@ You can install {longhorn-product-name} using a variety of tools, including {ran
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.1.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.1*.
 ====
 
 {longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
 
-== Post-release known issues
+== Post-release Known Issues
 
 For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
 
-== Resolved issues
+== Resolved Issues
 
 === Improvement
 
-* https://github.com/longhorn/longhorn/issues/12125[#12125] [BACKPORT][v1.10.1][IMPROVEMENT] The `auto-delete-pod-when-volume-detached-unexpectedly` should only focus on the kubernetes builtin workload.
+* https://github.com/longhorn/longhorn/issues/12125[#12125] [BACKPORT][v1.10.1][IMPROVEMENT] The `auto-delete-pod-when-volume-detached-unexpectedly` should only focus on the kubernetes builtin workload
 * https://github.com/longhorn/longhorn/issues/12036[#12036] [BACKPORT][v1.10.1][IMPROVEMENT] `CSIStorageCapacity` objects must show schedulable (allocatable) capacity
-* https://github.com/longhorn/longhorn/issues/12033[#12033] [BACKPORT][v1.10.1][IMPROVEMENT] improve error logging for failed mounting during node publish volume
+* https://github.com/longhorn/longhorn/issues/12033[#12033] [BACKPORT][v1.10.1][IMPROVEMENT] Improve error logging for failed mounting during node publish volume
 * https://github.com/longhorn/longhorn/issues/12020[#12020] [BACKPORT][v1.10.1][IMPROVEMENT] Improve Helm Chart defaultSettings handling with automatic quoting and multi-type support
 * https://github.com/longhorn/longhorn/issues/11945[#11945] [BACKPORT][v1.10.1][IMPROVEMENT] Avoid repeat engine restart when there are replica unavailable during migration
 * https://github.com/longhorn/longhorn/issues/11968[#11968] [BACKPORT][v1.10.1][IMPROVEMENT] Adjust maximum of GuaranteedInstanceManagerCPU to a big value
-* https://github.com/longhorn/longhorn/issues/11795[#11795] [BACKPORT][v1.10.1][IMPROVEMENT] Add usage metrics for Longhorn installation variant
+* https://github.com/longhorn/longhorn/issues/11795[#11795] [BACKPORT][v1.10.1][IMPROVEMENT] Add usage metrics for {longhorn-product-name} installation variant
 
 === Bug
 
 * https://github.com/longhorn/longhorn/issues/12089[#12089] [BACKPORT][v1.10.1][BUG] Backup target metric is broken
 * https://github.com/longhorn/longhorn/issues/12094[#12094] [BACKPORT][v1.10.1][BUG] Backing image download gets stuck after network disconnection
-* https://github.com/longhorn/longhorn/issues/12088[#12088] [BACKPORT][v1.10.1][BUG] panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 at longhorn-engine/pkg/controller/control.go:218 +0x2de]
+* https://github.com/longhorn/longhorn/issues/12088[#12088] [BACKPORT][v1.10.1][BUG] Panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 at longhorn-engine/pkg/controller/control.go:218 +0x2de]
 * https://github.com/longhorn/longhorn/issues/11964[#11964] [BACKPORT][v1.10.1][BUG] Unable to complete uninstallation due to the remaining backuptarget
 * https://github.com/longhorn/longhorn/issues/12043[#12043] [BACKPORT][v1.10.1][BUG] share-manager excessive memory usage
-* https://github.com/longhorn/longhorn/issues/12029[#12029] [BACKPORT][v1.10.1][BUG] NVME disk not found in v2 data engine (failed to find device for BDF)
+* https://github.com/longhorn/longhorn/issues/12029[#12029] [BACKPORT][v1.10.1][BUG] NVME disk not found in V2 data engine (failed to find device for BDF)
 * https://github.com/longhorn/longhorn/issues/11926[#11926] [BACKPORT][v1.10.1][BUG] NPE error during recurring job execution
-* https://github.com/longhorn/longhorn/issues/12026[#12026] [BACKPORT][v1.10.1][BUG] v2 volume creation failed on talos nodes
-* https://github.com/longhorn/longhorn/issues/12008[#12008] [BACKPORT][v1.10.1][BUG] mounting error is not properly hanedled during CSI node publish volume
+* https://github.com/longhorn/longhorn/issues/12026[#12026] [BACKPORT][v1.10.1][BUG] V2 volume creation failed on talos nodes
+* https://github.com/longhorn/longhorn/issues/12008[#12008] [BACKPORT][v1.10.1][BUG] Mounting error is not properly handled during CSI node publish volume
 * https://github.com/longhorn/longhorn/issues/12018[#12018] [BACKPORT][v1.10.1][BUG] Adding multiple disks to the same node concurrently may occasionally fail
-* https://github.com/longhorn/longhorn/issues/11886[#11886] [BUG] upgrading from 1.9.1 to 1.10.0 fails due to old resources still being in v1beta1
+* https://github.com/longhorn/longhorn/issues/11886[#11886] [BUG] Upgrading from 1.9.1 to 1.10.0 fails due to old resources still being in v1beta1
 * https://github.com/longhorn/longhorn/issues/11998[#11998] [BACKPORT][v1.10.1][BUG] DR volume gets stuck in `unknown` state if engine image is deleted from the attached node
 * https://github.com/longhorn/longhorn/issues/11996[#11996] [BACKPORT][v1.10.1][BUG] Volume gets stuck in `attaching` state if engine image is not deployed on one of nodes
-* https://github.com/longhorn/longhorn/issues/12000[#12000] [BACKPORT][v1.10.1][BUG] Unable to re-add block-type disks by BDF after re-enable v2 data engine
+* https://github.com/longhorn/longhorn/issues/12000[#12000] [BACKPORT][v1.10.1][BUG] Unable to re-add block-type disks by BDF after re-enable V2 data engine
 * https://github.com/longhorn/longhorn/issues/12005[#12005] [BACKPORT][v1.10.1][BUG] `test_system_backup_and_restore` test case failed on master-head
 * https://github.com/longhorn/longhorn/issues/11970[#11970] [BACKPORT][v1.10.1][BUG] Fix SPDK v25.05 CVE issue
 * https://github.com/longhorn/longhorn/issues/11976[#11976] [BACKPORT][v1.10.1][BUG] V2 volume stuck in volume attachment (V2 interrupt mode)
 * https://github.com/longhorn/longhorn/issues/11958[#11958] [BACKPORT][v1.10.1][BUG] RWX volume causes process uninterruptible sleep
 * https://github.com/longhorn/longhorn/issues/11865[#11865] [BACKPORT][v1.10.1][BUG] longhorn-manager fails to start after upgrading from 1.9.2 to 1.10.0
 * https://github.com/longhorn/longhorn/issues/11954[#11954] [BACKPORT][v1.10.1][BUG] Block disk deletion fails without error message
-* https://github.com/longhorn/longhorn/issues/11962[#11962] [BACKPORT][v1.10.1][BUG] Goroutine leak in instance-manager when using v2 data engine
-* https://github.com/longhorn/longhorn/issues/11942[#11942] [BACKPORT][v1.10.1][BUG] invalid memory address or nil pointer dereference
+* https://github.com/longhorn/longhorn/issues/11962[#11962] [BACKPORT][v1.10.1][BUG] Goroutine leak in instance-manager when using V2 data engine
+* https://github.com/longhorn/longhorn/issues/11942[#11942] [BACKPORT][v1.10.1][BUG] Invalid memory address or nil pointer dereference
 * https://github.com/longhorn/longhorn/issues/11918[#11918] [BACKPORT][v1.10.1][BUG] csi-provisioner silently fails to create CSIStorageCapacity if dataEngine parameter is missing
 * https://github.com/longhorn/longhorn/issues/11901[#11901] [BACKPORT][v1.10.1][BUG] longhorn-engine's UI panics
 * https://github.com/longhorn/longhorn/issues/11895[#11895] [BACKPORT][v1.10.1][BUG] Volume is unable to upgrade if the number of active replicas is larger than `volumme.spec.numberOfReplicas`
 * https://github.com/longhorn/longhorn/issues/11875[#11875] [BACKPORT][v1.10.1][BUG] UI fails to deploy when only IPv4 is enabled on nodes with v1.10.0 version
-* https://github.com/longhorn/longhorn/issues/11801[#11801] [BACKPORT][v1.10.1][BUG] Unable to detach a v2 volume after labeling `disable-v2-data-engine=true`
+* https://github.com/longhorn/longhorn/issues/11801[#11801] [BACKPORT][v1.10.1][BUG] Unable to detach a V2 volume after labeling `disable-v2-data-engine=true`
 
 === Misc
 
 * https://github.com/longhorn/longhorn/issues/11992[#11992] [BACKPORT][v1.10.1][REFACTOR] SAST checks for UI component
-* https://github.com/longhorn/longhorn/issues/11951[#11951] [HOTFIX] Create hotfixed image for longhorn-manager:v1.10.0
+* https://github.com/longhorn/longhorn/issues/11951[#11951] [HOTFIX] Create hotfixed image for `longhorn-manager:v1.10.0`

--- a/docs/version-1.10/modules/en/pages/release-notes/v1.10.2.adoc
+++ b/docs/version-1.10/modules/en/pages/release-notes/v1.10.2.adoc
@@ -65,7 +65,7 @@ For more details, see https://github.com/longhorn/longhorn/issues/12251[#12251].
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.2.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.2*.
 ====
 
 You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
@@ -74,7 +74,7 @@ You can install {longhorn-product-name} using a variety of tools, including {ran
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.2.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.2*.
 ====
 
 {longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
@@ -88,7 +88,7 @@ For information about issues identified after this release, see https://github.c
 === Feature
 
 * https://github.com/longhorn/longhorn/issues/12245[#12245] [BACKPORT][v1.10.2][FEATURE] Inherit namespace for longhorn-share-manager in FastFailover mode
-* https://github.com/longhorn/longhorn/issues/12181[#12181] [BACKPORT][v1.10.2][FEATURE] [Dependency] aws-sdk-go v1.55.7 is EOL as of 2025-07-31 — plan to migrate to v2?
+* https://github.com/longhorn/longhorn/issues/12181[#12181] [BACKPORT][v1.10.2][FEATURE] [Dependency] aws-sdk-go v1.55.7 is EOL as of 2025-07-31 — plan to migrate to V2?
 
 === Improvement
 
@@ -106,7 +106,7 @@ For information about issues identified after this release, see https://github.c
 * https://github.com/longhorn/longhorn/issues/12494[#12494] [BACKPORT][v1.10.2][BUG] Single replica volume could get stuck in attaching/detaching loop after the replica node rebooted
 * https://github.com/longhorn/longhorn/issues/12200[#12200] [BACKPORT][v1.10.2][BUG] Potential Instance Manager Client Context Leak
 * https://github.com/longhorn/longhorn/issues/12476[#12476] [BACKPORT][v1.10.2][BUG] SnapshotBack proxy request might be sent to incorrect instance-manager pod
-* https://github.com/longhorn/longhorn/issues/12451[#12451] [BACKPORT][v1.10.2][BUG] unknown OS condition in node CR is not properly removed during upgrade
+* https://github.com/longhorn/longhorn/issues/12451[#12451] [BACKPORT][v1.10.2][BUG] Unknown OS condition in node CR is not properly removed during upgrade
 * https://github.com/longhorn/longhorn/issues/12231[#12231] [BACKPORT][v1.10.2][BUG] RWX volume becomes unavailable after drain node
 * https://github.com/longhorn/longhorn/issues/12382[#12382] [BACKPORT][v1.10.2][BUG] mounting error is not properly hanedled during CSI node publish volume
 * https://github.com/longhorn/longhorn/issues/12368[#12368] [BACKPORT][v1.10.2][BUG] Encrypted Volume Cannot Be Expanded Online
@@ -118,6 +118,6 @@ For information about issues identified after this release, see https://github.c
 * https://github.com/longhorn/longhorn/issues/12270[#12270] [BACKPORT][v1.10.2][BUG] short name mode is enforcing, but image name longhornio/longhorn-manager:v1.10. │ │ 0 returns ambiguous list
 * https://github.com/longhorn/longhorn/issues/12115[#12115] [BACKPORT][v1.10.2][BUG] Replicas accumulate during engine upgrade
 * https://github.com/longhorn/longhorn/issues/12195[#12195] [BACKPORT][v1.10.2][BUG] Potential BackingImageManagerClient Connection and Context Leak
-* https://github.com/longhorn/longhorn/issues/12251[#12251] [BACKPORT][v1.10.2][BUG] Longhorn ignores `Replica Node Level Soft Anti-Affinity` when auto balance is set to `best-effort`
-* https://github.com/longhorn/longhorn/issues/12234[#12234] [BACKPORT][v1.10.2][BUG] invalid memory address or nil pointer dereference (again)
+* https://github.com/longhorn/longhorn/issues/12251[#12251] [BACKPORT][v1.10.2][BUG] {longhorn-product-name} ignores `Replica Node Level Soft Anti-Affinity` when auto balance is set to `best-effort`
+* https://github.com/longhorn/longhorn/issues/12234[#12234] [BACKPORT][v1.10.2][BUG] Invalid memory address or nil pointer dereference (again)
 * https://github.com/longhorn/longhorn/issues/12213[#12213] [BACKPORT][v1.10.2][BUG] Request Header Or Cookie Too Large in Web UI with OIDC auth

--- a/docs/version-1.10/modules/en/pages/release-notes/v1.10.2.adoc
+++ b/docs/version-1.10/modules/en/pages/release-notes/v1.10.2.adoc
@@ -1,0 +1,123 @@
+= {longhorn-product-name} v1.10.2 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For terminology and context on {longhorn-product-name} releases, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Important fixes
+
+This release includes several critical stability fixes.
+
+=== RWX volume unavailable after node drain
+
+Fixed a race condition where *ReadWriteMany (RWX) volumes* could remain in the _attaching_ state after node drains, causing workloads to become unavailable.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12231[#12231].
+
+=== Encrypted volume cannot be expanded online
+
+Fixed an where online expansion of encrypted volumes did not propagate the new size to the dm-crypt device.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12368[#12368].
+
+=== Cloned volume cannot be attached to workload
+
+Fixed a bug where cloned volumes could fail to reach a healthy state, preventing attachment to workloads.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12208[#12208].
+
+=== Block mode volume migration stuck
+
+Fixed a regression in block-mode volume migrations where newly created replicas could incorrectly inherit the `lastFailedAt` timestamp from source replicas, causing repeated deletion and blocking migration completion.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12312[#12312].
+
+=== Replica auto balance disk pressure threshold stalled
+
+Fixed an issue where replica auto-balance under disk pressure could be blocked if stopped volumes were present on the disk.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12334[#12334].
+
+=== Replicas accumulate during engine upgrade
+
+Fixed a bug where temporary replicas could accumulate during engine upgrade. High etcd latency could cause new replicas to fail verification, leading to accumulation over multiple reconciliation cycles.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12115[#12115].
+
+=== Potential client connection and context leak
+
+Fixed potential context leaks in the instance manager client and backing image manager client, improving stability and preventing resource exhaustion.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12200[#12200] and https://github.com/longhorn/longhorn/issues/12195[#12195].
+
+=== Replica node level soft anti-affinity ignored
+
+Fixed a bug of replica scheduling loop where replicas could be scheduled onto nodes that already host a replica, even when _Replica Node-Level Soft Anti-Affinity_ was disabled.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12251[#12251].
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.10.2.*
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.9.x to v1.10.2.*
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release known issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved issues
+
+=== Feature
+
+* https://github.com/longhorn/longhorn/issues/12245[#12245] [BACKPORT][v1.10.2][FEATURE] Inherit namespace for longhorn-share-manager in FastFailover mode
+* https://github.com/longhorn/longhorn/issues/12181[#12181] [BACKPORT][v1.10.2][FEATURE] [Dependency] aws-sdk-go v1.55.7 is EOL as of 2025-07-31 — plan to migrate to v2?
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/12329[#12329] [BACKPORT][v1.10.2][IMPROVEMENT] Fix V2 Volume CSI Clone Slowness Caused by VolumeAttachment Webhook Blocking
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/12536[#12536] [BACKPORT][v1.10.2][BUG] `instance-manager` on nodes that do not have hard or solid state disk DDOSing cluster DNS server with TXT query `_grpc_config.localhost`
+* https://github.com/longhorn/longhorn/issues/12518[#12518] [BACKPORT] Replica rebuild, clone and restore fail, traffic being sent to HTTP proxy
+* https://github.com/longhorn/longhorn/issues/12512[#12512] [BACKPORT][v1.10.2][BUG] Healthy replica could be deleted unexpectedly after reducing volume's number of replicas
+* https://github.com/longhorn/longhorn/issues/12509[#12509] [BACKPORT][v1.10.2][BUG] Data locality enabled volume fails to remove an existing running replica after numberOfReplicas reduced
+* https://github.com/longhorn/longhorn/issues/12479[#12479] [BACKPORT][v1.10.2][BUG] System backup may fail to be created or deleted
+* https://github.com/longhorn/longhorn/issues/12222[#12222] [BACKPORT][v1.10.2][BUG] Some default settings in questions.yaml are placed incorrectly.
+* https://github.com/longhorn/longhorn/issues/12482[#12482] [BACKPORT][v1.10.2][BUG] Auto balance feature may lead to volumes falling into a replica deletion-recreation loop
+* https://github.com/longhorn/longhorn/issues/12494[#12494] [BACKPORT][v1.10.2][BUG] Single replica volume could get stuck in attaching/detaching loop after the replica node rebooted
+* https://github.com/longhorn/longhorn/issues/12200[#12200] [BACKPORT][v1.10.2][BUG] Potential Instance Manager Client Context Leak
+* https://github.com/longhorn/longhorn/issues/12476[#12476] [BACKPORT][v1.10.2][BUG] SnapshotBack proxy request might be sent to incorrect instance-manager pod
+* https://github.com/longhorn/longhorn/issues/12451[#12451] [BACKPORT][v1.10.2][BUG] unknown OS condition in node CR is not properly removed during upgrade
+* https://github.com/longhorn/longhorn/issues/12231[#12231] [BACKPORT][v1.10.2][BUG] RWX volume becomes unavailable after drain node
+* https://github.com/longhorn/longhorn/issues/12382[#12382] [BACKPORT][v1.10.2][BUG] mounting error is not properly hanedled during CSI node publish volume
+* https://github.com/longhorn/longhorn/issues/12368[#12368] [BACKPORT][v1.10.2][BUG] Encrypted Volume Cannot Be Expanded Online
+* https://github.com/longhorn/longhorn/issues/12357[#12357] [BACKPORT][v1.10.2][BUG] The auo generated backing image pod name is complained by kubelet
+* https://github.com/longhorn/longhorn/issues/12342[#12342] [BACKPORT][v1.10.2][BUG] `tests.test_cloning.test_cloning_basic` fails at msater-head
+* https://github.com/longhorn/longhorn/issues/12208[#12208] [BACKPORT][v1.10.2][Bug] A cloned volume cannot be attached to a workload
+* https://github.com/longhorn/longhorn/issues/12312[#12312] [BACKPORT][v1.10.2][BUG] Block Mode Volume Migration Stuck
+* https://github.com/longhorn/longhorn/issues/12334[#12334] [BACKPORT][v1.10.2][BUG] Replica auto balance disk pressure threshold stalled with stopped volumes
+* https://github.com/longhorn/longhorn/issues/12270[#12270] [BACKPORT][v1.10.2][BUG] short name mode is enforcing, but image name longhornio/longhorn-manager:v1.10. │ │ 0 returns ambiguous list
+* https://github.com/longhorn/longhorn/issues/12115[#12115] [BACKPORT][v1.10.2][BUG] Replicas accumulate during engine upgrade
+* https://github.com/longhorn/longhorn/issues/12195[#12195] [BACKPORT][v1.10.2][BUG] Potential BackingImageManagerClient Connection and Context Leak
+* https://github.com/longhorn/longhorn/issues/12251[#12251] [BACKPORT][v1.10.2][BUG] Longhorn ignores `Replica Node Level Soft Anti-Affinity` when auto balance is set to `best-effort`
+* https://github.com/longhorn/longhorn/issues/12234[#12234] [BACKPORT][v1.10.2][BUG] invalid memory address or nil pointer dereference (again)
+* https://github.com/longhorn/longhorn/issues/12213[#12213] [BACKPORT][v1.10.2][BUG] Request Header Or Cookie Too Large in Web UI with OIDC auth

--- a/docs/version-1.11/modules/en/nav.adoc
+++ b/docs/version-1.11/modules/en/nav.adoc
@@ -1,9 +1,22 @@
+// SUSE Storage Documentation Section:
 * xref:longhorn-documentation.adoc[]
+
+// Release Notes Section:
+* Release Notes
+** xref:release-notes/v1.11.1.adoc[]
+** xref:release-notes/v1.11.2.adoc[]
+** xref:release-notes/v1.11.3.adoc[]
+
+// Introduction Section:
 * xref:introduction/introduction.adoc[]
 ** xref:introduction/concepts.adoc[]
 ** xref:introduction/terminology.adoc[]
 ** xref:introduction/document-conventions.adoc[]
+
+// Important Notes Section:
 * xref:important-notes.adoc[]
+
+// Installation and Setup Section:
 * Installation and Setup
 ** xref:installation-setup/requirements.adoc[]
 ** xref:installation-setup/best-practices.adoc[]
@@ -22,6 +35,8 @@
 *** xref:installation-setup/os-distro/k3s.adoc[]
 ** xref:installation-setup/setup-performance-scalability-sizing-guidelines.adoc[]
 ** xref:installation-setup/uninstallation.adoc[]
+
+// Upgrades Section:
 * xref:upgrades/upgrades.adoc[]
 ** Component Upgrades
 *** xref:upgrades/longhorn-components/auto-upgrade-engine.adoc[]
@@ -32,8 +47,12 @@
 *** xref:upgrades/kubernetes/upgrade-k8s-on-aks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-eks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-gke.adoc[]
+
+// Migration Section:
 * Migration
 ** xref:migration/migration.adoc[]
+
+// SUSE Storage System Section:
 * SUSE® Storage System
 ** xref:longhorn-system/system-access/system-access.adoc[]
 *** xref:longhorn-system/system-access/longhorn-ui.adoc[]
@@ -64,6 +83,8 @@
 *** xref:longhorn-system/v2-data-engine/performance.adoc[]
 ** xref:longhorn-system/examples-resources.adoc[]
 ** xref:longhorn-system/migrate-flexvolume.adoc[]
+
+// Nodes Section:
 * Nodes
 ** xref:nodes/node-space-usage.adoc[]
 ** xref:nodes/default-disk-and-node-config.adoc[]
@@ -80,6 +101,8 @@
 *** xref:nodes/managed-kubernetes/aks-managed-node-groups.adoc[]
 *** xref:nodes/managed-kubernetes/eks-managed-node-pools.adoc[]
 *** xref:nodes/managed-kubernetes/gke-managed-node-pools.adoc[]
+
+// Volumes Section:
 * Volumes
 ** xref:volumes/create-volumes.adoc[]
 ** xref:volumes/pvc-ownership-and-permission.adoc[]
@@ -99,6 +122,8 @@
 ** xref:volumes/storageclass-parameters.adoc[]
 ** xref:volumes/backing-images/backing-images.adoc[]
 *** xref:volumes/backing-images/backing-image-encryption.adoc[]
+
+// High Availability Section:
 * High Availability
 ** xref:high-availability/automatic-replica-balancing.adoc[]
 ** xref:high-availability/replica-rebuilding.adoc[]
@@ -110,6 +135,8 @@
 ** xref:high-availability/rwx-volume-fast-failover.adoc[]
 ** xref:high-availability/volume-recovery.adoc[]
 ** xref:high-availability/node-failure.adoc[]
+
+// Snapshots and Backups Section:
 * Snapshots and Backups
 ** xref:snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.adoc[]
 *** xref:snapshots-backups/volume-snapshots-backups/create-snapshot.adoc[]
@@ -133,6 +160,8 @@
 *** xref:snapshots-backups/system-backups/restore-system.adoc[]
 ** xref:snapshots-backups/backing-image-backups.adoc[]
 ** xref:snapshots-backups/restore-cluster-rancher-snapshot.adoc[]
+
+// Data Integrity and Recovery Section:
 * Data Integrity and Recovery
 ** xref:data-integrity-recovery/snapshot-data-integrity-check.adoc[]
 ** xref:data-integrity-recovery/orphaned-data-cleanup.adoc[]
@@ -144,6 +173,8 @@
 *** xref:data-integrity-recovery/data-recovery/recover-from-data-errors.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-from-full-disk.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-without-system.adoc[]
+
+// Observability Section:
 * Observability
 ** xref:observability/configure-prometheus-grafana.adoc[]
 ** xref:observability/alert-rule-examples.adoc[]
@@ -151,10 +182,14 @@
 ** xref:observability/disk-health.adoc[]
 ** xref:observability/integrate-with-rancher-monitoring.adoc[]
 ** xref:observability/kubelet-volume-metrics.adoc[]
+
+// Troubleshooting and Maintenance Section:
 * Troubleshooting and Maintenance
 ** xref:troubleshooting-maintenance/support-bundle.adoc[]
 ** xref:troubleshooting-maintenance/troubleshooting.adoc[]
 ** xref:troubleshooting-maintenance/v2-data-engine-issues.adoc[]
 ** xref:troubleshooting-maintenance/maintenance.adoc[]
+
+// Glossary Section:
 * Glossary
 ** xref:glossary/glossary.adoc[]

--- a/docs/version-1.11/modules/en/pages/release-notes/v1.11.1.adoc
+++ b/docs/version-1.11/modules/en/pages/release-notes/v1.11.1.adoc
@@ -1,0 +1,165 @@
+= {longhorn-product-name} v1.11.1 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For terminology and context on {longhorn-product-name} releases, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Deprecations
+
+=== V2 Backing Image deprecation
+
+The Backing Image feature for the V2 Data Engine is now deprecated in v1.11.0 and is scheduled for removal in v1.12.0.
+
+Users using V2 volumes for virtual machines are encouraged to adopt the https://kubevirt.io/user-guide/operations/containerized_data_importer/[Containerized Data Importer (CDI)] for volume population instead.
+
+https://github.com/longhorn/longhorn/issues/12237[#12237]
+
+== Primary Highlights
+
+=== V2 Data Engine
+
+==== Now in technical preview stage
+
+We are pleased to announce that the V2 Data Engine has officially graduated to the *Technical Preview* stage. This indicates increased stability and feature maturity as we move toward General Availability.
+
+[NOTE]
+====
+*Limitation*: While the engine is in Technical Preview, live upgrade is not supported yet. V2 volumes must be detached (offline) before engine upgrade.
+====
+
+==== Support for `ublk` front-end
+
+Users can now configure `ublk` (Userspace Block Device) as the front-end for V2 Data Engine volumes. This provides a high-performance alternative to the NVMe-oF front-end for environments running Kernel v6.0+.
+
+https://github.com/longhorn/longhorn/issues/11039[#11039]
+
+=== V1 Data Engine
+
+==== Faster replica rebuilding from multiple sources
+
+The V1 Data Engine now supports parallel rebuilding. When a replica needs to be rebuilt, the engine can now stream data from multiple healthy replicas simultaneously rather than a single source. This reduces the time required to restore redundancy for volumes containing tons of scattered data chunks.
+
+https://github.com/longhorn/longhorn/issues/11331[#11331]
+
+=== General
+
+==== Balance-aware algorithm disk selection for replica scheduling
+
+{longhorn-product-name} improves the disk selection for the replica scheduling by introducing an intelligent `balance-aware` scheduling algorithm, reducing uneven storage usage across nodes and disks.
+
+https://github.com/longhorn/longhorn/issues/10512[#10512]
+
+==== Node disk health monitoring
+
+{longhorn-product-name} now actively monitors the physical health of the underlying disks used for storage by using `S.M.A.R.T.` data. This allows administrators to identify issues and raise alerts when abnormal SMART metrics are detected, helping prevent failed volumes.
+
+https://github.com/longhorn/longhorn/issues/12016[#12016]
+
+==== Share manager networking
+
+Users can now configure an extra network interface for the Share Manager to support complex network segmentation requirements.
+
+https://github.com/longhorn/longhorn/issues/10269[#10269]
+
+==== ReadWriteOncePod (RWOP) support
+
+Full support for the Kubernetes `ReadWriteOncePod` access mode has been added.
+
+https://github.com/longhorn/longhorn/issues/9727[#9727]
+
+==== StorageClass `allowedTopologies` support
+
+Administrators can now use the `allowedTopologies` field in {longhorn-product-name} StorageClasses to restrict volume provisioning to specific zones, regions or nodes within the cluster.
+
+https://github.com/longhorn/longhorn/issues/12261[#12261]
+
+== Important Fixes
+
+This release includes several critical stability fixes.
+
+=== {longhorn-product-name} workload pods memory leak
+
+Fixed a critical regression where proxy connection leaks in the longhorn-instance-manager pods caused high memory consumption.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12575[#12575].
+
+=== Backup and restore compatibility fix
+
+Resolved compatibility issues introduced by aws-go-sdk v2, including backups to S3-compatible storage (like Storj or Google Cloud Storage). This fix ensures the completion of large data transfers to remote backup targets with correct authorization.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12714[#12714] and https://github.com/longhorn/longhorn/issues/12688[#12688].
+
+=== V2 Data Engine (SPDK) refinements
+
+Several enhancements were delivered for certain V2 Data Engine features, including fast replica rebuild and clone.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12751[#12751] and https://github.com/longhorn/longhorn/issues/12748[#12748].
+
+=== CSI scheduling enhancement
+
+Support CSI topology-aware PV nodeAffinity control.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12689[#12689] and https://github.com/longhorn/longhorn/issues/12656[#12656].
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.11.1*.
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.10.x or v1.11.0 to v1.11.1*.
+
+*Users on v1.11.0 who experienced the memory leaks of longhorn-instance-manager pods https://github.com/longhorn/longhorn/issues/12575[#12575] are highly encouraged to upgrade to v1.11.1 to receive the permanent fix for the proxy connection leaks*.
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release Known Issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved Issues in This Release
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/12751[#12751] [BACKPORT][v1.11.1][IMPROVEMENT] Ensure V2 Engine ReplicaAdd respects the fast-replica-rebuild-enabled setting
+* https://github.com/longhorn/longhorn/issues/12689[#12689] [BACKPORT][v1.11.1][IMPROVEMENT] Topology-aware PV nodeAffinity control: allowedTopologies keys + strictTopology
+* https://github.com/longhorn/longhorn/issues/12585[#12585] [BACKPORT][v1.11.1][IMPROVEMENT] detailed log for the reason of node controller deleting backing image copies
+* https://github.com/longhorn/longhorn/issues/12711[#12711] [BACKPORT][v1.11.1][IMPROVEMENT] Relax `endpoint-network-for-rwx-volume` validation for migratable block-mode volumes
+* https://github.com/longhorn/longhorn/issues/12694[#12694] [BACKPORT][v1.11.1][IMPROVEMENT] RBAC permissions for csi-resizer
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/12768[#12768] [BACKPORT][v1.11.1][BUG] Failed replicas accumulate during engine upgrade
+* https://github.com/longhorn/longhorn/issues/12748[#12748] [BACKPORT][v1.11.1][BUG] V2 Volume Clone Status is Changed Over Time
+* https://github.com/longhorn/longhorn/issues/12714[#12714] [BACKPORT][v1.11.1][BUG] Backup to S3 fails at 95%
+* https://github.com/longhorn/longhorn/issues/12738[#12738] [BACKPORT][v1.11.1][BUG] `spdk_tgt` encountered an assertion failure in `longhorn-spdk-helper` during a CI test run
+* https://github.com/longhorn/longhorn/issues/12688[#12688] [BACKPORT][v1.11.1][BUG] Google Cloud Storage (GCS) backup target always fails with SignatureDoesNotMatch due to AWS SDK Go v2 CRC32 checksum incompatibility
+* https://github.com/longhorn/longhorn/issues/12730[#12730] [BACKPORT][v1.11.1][BUG] Enable to set `defaultSettings.nodeDiskHealthMonitoring`
+* https://github.com/longhorn/longhorn/issues/12704[#12704] [BACKPORT][v1.11.1][BUG] stale name variable in nsmounter get_pid
+* https://github.com/longhorn/longhorn/issues/12665[#12665] [BACKPORT][v1.11.1][BUG] After upgrading to 1.11.0, new persistent volumes have nodeAffinity
+* https://github.com/longhorn/longhorn/issues/12661[#12661] [BACKPORT][v1.11.1][BUG] Incorrect storage double-counting causes scheduling failure when multiple replicas exist on the same node
+* https://github.com/longhorn/longhorn/issues/12641[#12641] [BACKPORT][v1.11.1][BUG] Recreated block disk with same name never becomes schedulable after volume and disk deletion
+* https://github.com/longhorn/longhorn/issues/12618[#12618] [BACKPORT][v1.11.1][BUG] {longhorn-product-name} v1.10 Volume API is not compatible with the v1.8.1 manifest
+* https://github.com/longhorn/longhorn/issues/12626[#12626] [BACKPORT][v1.11.1][BUG] [V2] Can not use partition as block device
+* https://github.com/longhorn/longhorn/issues/12615[#12615] [BACKPORT][v1.11.1][BUG] `Volume.Spec.CloneMode` is empty after upgrading to v1.10.x and following version
+* https://github.com/longhorn/longhorn/issues/12589[#12589] [BACKPORT][v1.11.1][BUG] {longhorn-product-name} validating webhook blocks k3s server node joins - flannel CNI fails to initialize
+* https://github.com/longhorn/longhorn/issues/12575[#12575] [BACKPORT][v1.11.1][BUG] V1.11.0 very high memory consumption for the instance manager
+* https://github.com/longhorn/longhorn/issues/12780[#12780] [BACKPORT][v1.11.1][BUG] Backing image data source pod fails when HTTP proxy is enabled
+* https://github.com/longhorn/longhorn/issues/12788[#12788] [BACKPORT][v1.11.1][BUG] orphan controller does not cleanup the instance on the corresponding instance manager on a multiple IM node
+
+=== Stability
+
+* https://github.com/longhorn/longhorn/issues/12733[#12733] [BACKPORT][v1.11.1][BUG] Potential NEP in Volume Metrics Collector

--- a/docs/version-1.11/modules/en/pages/release-notes/v1.11.2.adoc
+++ b/docs/version-1.11/modules/en/pages/release-notes/v1.11.2.adoc
@@ -1,0 +1,78 @@
+= {longhorn-product-name} v1.11.2 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For terminology and context on {longhorn-product-name} releases, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Important Fixes
+
+This release includes several critical stability fixes.
+
+=== Replica rebuild progress fix
+
+Resolved an issue where replica rebuild progress could exceed 100% under unstable network conditions. Progress reporting is now capped at 100%.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12949[#12949].
+
+=== CSIStorageCapacity scheduling enhancement
+
+Introduced a new setting to control CSIStorageCapacity reporting. Previously, compute nodes without {longhorn-product-name} disks incorrectly reported 0 capacity, breaking WaitForFirstConsumer scheduling. With this enhancement, capacity tracking can be configured to avoid rejecting compute nodes in separated compute/storage architectures.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12807[#12807].
+
+== Improvement
+
+=== Manager memory optimization
+
+Optimized longhorn-manager Pod informer caching to reduce cluster-wide memory usage.
+
+For more details, see https://github.com/longhorn/longhorn/issues/12771[#12771].
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.11.2*.
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.10.x or v1.11.0 to v1.11.2*.
+
+*Users on v1.11.0 who experienced the memory leaks of longhorn-instance-manager pods https://github.com/longhorn/longhorn/issues/12575[#12575] are highly encouraged to upgrade to v1.11.2 to receive the permanent fix for the proxy connection leaks*.
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release Known Issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved Issues in This Release
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/12819[#12819] [BACKPORT][v1.11.2][IMPROVEMENT] Reduce longhorn-manager memory usage by optimizing cluster-wide informer caching
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/13006[#13006] [BACKPORT][v1.11.2][BUG] Test case `test_storage_capacity_aware_pod_scheduling` fails
+* https://github.com/longhorn/longhorn/issues/12928[#12928] [BACKPORT][v1.11.2][BUG] Replica Auto-Balance Causes Infinite Replica Scheduling Loop
+* https://github.com/longhorn/longhorn/issues/12918[#12918] [BACKPORT][v1.11.2][BUG] CSIStorageCapacity reports 0 for compute nodes without {longhorn-product-name} disks, breaking WaitForFirstConsumer scheduling
+* https://github.com/longhorn/longhorn/issues/12952[#12952] [BACKPORT][v1.11.2][BUG] Replica rebuild progress can go over 100%
+* https://github.com/longhorn/longhorn/issues/12945[#12945] [BACKPORT][v1.11.2][BUG] Node exhaustion caused by backup inspect buildup induced due to NFS latency
+* https://github.com/longhorn/longhorn/issues/12911[#12911] [BACKPORT][v1.11.2][BUG] Failed to collect health data for block disk (AIO) when disk path is a `/dev/disk/by-id` symlink
+* https://github.com/longhorn/longhorn/issues/12856[#12856] [BACKPORT][v1.11.2][BUG] "snapshot becomes not ready to use" Warning events emitted during expected auto-cleanup after backup
+
+=== Stability
+
+* https://github.com/longhorn/longhorn/issues/12733[#12733] [BACKPORT][v1.11.1][BUG] Potential NEP in Volume Metrics Collector

--- a/docs/version-1.11/modules/en/pages/release-notes/v1.11.3.adoc
+++ b/docs/version-1.11/modules/en/pages/release-notes/v1.11.3.adoc
@@ -1,0 +1,94 @@
+= {longhorn-product-name} v1.11.3 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For terminology and context on {longhorn-product-name} releases, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Important Fixes
+
+This release includes several critical stability fixes.
+
+=== V1 volumes not operable fix after `iscsid` restart
+
+Resolved the issue caused by the `iscsid` restart where volume operations could become stuck or fail, including PVC resize failures.
+
+For more details, see https://github.com/longhorn/longhorn/issues/13411[#13411], https://github.com/longhorn/longhorn/issues/13413[#13413], and https://github.com/longhorn/longhorn/issues/13383[#13383].
+
+=== Replica rebuild stability fix
+
+Fixed a nil pointer dereference panic in `longhorn-instance-manager` during replica rebuild, improving rebuild stability under failure conditions.
+
+For more details, see https://github.com/longhorn/longhorn/issues/13129[#13129].
+
+=== Migration engine readiness transition fix
+
+Resolved an issue where the migration engine could be unexpectedly deleted while the target node was still transitioning to ready, which could interrupt migration workflows.
+
+For more details, see https://github.com/longhorn/longhorn/issues/13133[#13133].
+
+=== Recurring trim job deadlock fix
+
+Resolved a deadlock that could cause recurring trim jobs to fail.
+
+For more details, see https://github.com/longhorn/longhorn/issues/13424[#13424].
+
+== Installation
+
+[IMPORTANT]
+====
+*Due to the upgrade of the CSI external provisioner to v6.3.0, ensure that your cluster is running Kubernetes v1.34 or later before installing {longhorn-product-name} v1.11.3*.
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Due to the upgrade of the CSI external provisioner to v6.3.0, ensure that your cluster is running Kubernetes v1.34 or later before upgrading from {longhorn-product-name} v1.10.x or v1.11.0 to v1.11.3*.
+
+*Users on v1.11.0 who experienced the memory leaks of longhorn-instance-manager pods https://github.com/longhorn/longhorn/issues/12575[#12575] are highly encouraged to upgrade to v1.11.3 to receive the permanent fix for the proxy connection leaks*.
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release Known Issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved Issues in This Release
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/13116[#13116] [BACKPORT][v1.11.3][IMPROVEMENT] longhorn-manager pods race on webhook TLS Secret at scale
+* https://github.com/longhorn/longhorn/issues/13283[#13283] [BACKPORT][v1.11.3][IMPROVEMENT] Add metrics to collect information about LONGHORN_DISTRO
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/13411[#13411] [BACKPORT][v1.11.3][BUG] volume expansion stuck
+* https://github.com/longhorn/longhorn/issues/13413[#13413] [BACKPORT][v1.11.3][BUG] pvc resize fails after iscsid restart
+* https://github.com/longhorn/longhorn/issues/13383[#13383] [BACKPORT][v1.11.3][BUG] expanding the volume fails
+* https://github.com/longhorn/longhorn/issues/13133[#13133] [BACKPORT][v1.11.3][BUG] Migration Engine Can Be Unexpectedly Deleted If the Target Node Is Still in Readiness Transition
+* https://github.com/longhorn/longhorn/issues/13211[#13211] [BACKPORT][v1.11.3][BUG] System Backup RecurringJob retention prunes newest CR — sorts by `Status.CreatedAt` (zero for Error/racing CRs)
+* https://github.com/longhorn/longhorn/issues/13296[#13296] [BACKPORT][v1.11.3][BUG] when uploading backup to S3 storage (NetApp appliance) it fails
+* https://github.com/longhorn/longhorn/issues/13270[#13270] [BACKPORT][v1.11.3][BUG] spdk interrupt mode value is missing in `pass:[chart/values.yaml]`
+* https://github.com/longhorn/longhorn/issues/13129[#13129] [BACKPORT][v1.11.3][BUG] nil pointer dereference panic in instance-manager during replica rebuild.
+* https://github.com/longhorn/longhorn/issues/13200[#13200] [BACKPORT][v1.11.3][BUG] Test Encrypted Volume Upgrade: Old-engine RWO volume shows 1008 MiB after expansion to 2 GiB instead of expected 2032 MiB
+* https://github.com/longhorn/longhorn/issues/13124[#13124] [BACKPORT][v1.11.3][BUG] HTTP response body leaks in support bundle status polling and webhook readiness checks
+* https://github.com/longhorn/longhorn/issues/13099[#13099] [BACKPORT][v1.11.3][BUG] `global.cattle.systemDefaultRegistry` is not applied as the image registry prefix in `108.2.1+up1.10.2`
+* https://github.com/longhorn/longhorn/issues/13080[#13080] [BACKPORT][v1.11.3][BUG] [longhorn-engine/dataserver] Handling EOF returned by `io.ReadFull` robustly
+* https://github.com/longhorn/longhorn/issues/13088[#13088] [BACKPORT][v1.11.3][BUG] `PrometheusTimeseriesCardinality` for metric `longhorn_rest_client_rate_limiter_latency_seconds_bucket`
+* https://github.com/longhorn/longhorn/issues/13424[#13424] [BACKPORT][v1.11.3][BUG] Recurring trim job fails with deadlock
+
+=== Stability
+
+* https://github.com/longhorn/longhorn/issues/13247[#13247] [BACKPORT][v1.11.3][BUG] longhorn-manager panic in `BackupController.setInprogressDeletionMap` during backup deletion
+
+=== Misc
+
+* https://github.com/longhorn/longhorn/issues/13278[#13278] [BACKPORT][v1.11.3][TASK] Add distro information to upgrade responder requests

--- a/docs/version-1.9/modules/en/nav.adoc
+++ b/docs/version-1.9/modules/en/nav.adoc
@@ -1,9 +1,21 @@
+// SUSE Storage Longhorn Documentation Section:
 * xref:longhorn-documentation.adoc[]
+
+// Release Notes Section:
+* Release Notes
+** xref:release-notes/v1.9.1.adoc[]
+** xref:release-notes/v1.9.2.adoc[]
+
+// Introduction Section:
 * xref:introduction/introduction.adoc[]
 ** xref:introduction/concepts.adoc[]
 ** xref:introduction/terminology.adoc[]
 ** xref:introduction/document-conventions.adoc[]
+
+// Important Notes Section:
 * xref:important-notes.adoc[]
+
+// Installation and Setup Section:
 * Installation and Setup
 ** xref:installation-setup/requirements.adoc[]
 ** xref:installation-setup/best-practices.adoc[]
@@ -22,6 +34,8 @@
 *** xref:installation-setup/os-distro/k3s.adoc[]
 ** xref:installation-setup/setup-performance-scalability-sizing-guidelines.adoc[]
 ** xref:installation-setup/uninstallation.adoc[]
+
+// Upgrades Section:
 * xref:upgrades/upgrades.adoc[]
 ** Component Upgrades
 *** xref:upgrades/longhorn-components/auto-upgrade-engine.adoc[]
@@ -32,8 +46,12 @@
 *** xref:upgrades/kubernetes/upgrade-k8s-on-aks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-eks.adoc[]
 *** xref:upgrades/kubernetes/upgrade-k8s-on-gke.adoc[]
+
+// Migration Section:
 * Migration
 ** xref:migration/migration.adoc[]
+
+// SUSE Storage System Section:
 * SUSE® Storage System
 ** xref:longhorn-system/system-access/system-access.adoc[]
 *** xref:longhorn-system/system-access/longhorn-ui.adoc[]
@@ -59,6 +77,8 @@
 *** xref:longhorn-system/v2-data-engine/performance.adoc[]
 ** xref:longhorn-system/examples-resources.adoc[]
 ** xref:longhorn-system/migrate-flexvolume.adoc[]
+
+// Noes Section:
 * Nodes
 ** xref:nodes/node-space-usage.adoc[]
 ** xref:nodes/default-disk-and-node-config.adoc[]
@@ -74,6 +94,8 @@
 *** xref:nodes/managed-kubernetes/aks-managed-node-groups.adoc[]
 *** xref:nodes/managed-kubernetes/eks-managed-node-pools.adoc[]
 *** xref:nodes/managed-kubernetes/gke-managed-node-pools.adoc[]
+
+// Volumes Section:
 * Volumes
 ** xref:volumes/create-volumes.adoc[]
 ** xref:volumes/pvc-ownership-and-permission.adoc[]
@@ -92,6 +114,8 @@
 ** xref:volumes/storageclass-parameters.adoc[]
 ** xref:volumes/backing-images/backing-images.adoc[]
 *** xref:volumes/backing-images/backing-image-encryption.adoc[]
+
+// High Availability Section:
 * High Availability
 ** xref:high-availability/automatic-replica-balancing.adoc[]
 ** xref:high-availability/fast-replica-rebuilding.adoc[]
@@ -102,6 +126,8 @@
 ** xref:high-availability/rwx-volume-fast-failover.adoc[]
 ** xref:high-availability/volume-recovery.adoc[]
 ** xref:high-availability/node-failure.adoc[]
+
+// Snapshots and Backups Section:
 * Snapshots and Backups
 ** xref:snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.adoc[]
 *** xref:snapshots-backups/volume-snapshots-backups/create-snapshot.adoc[]
@@ -125,6 +151,8 @@
 *** xref:snapshots-backups/system-backups/restore-system.adoc[]
 ** xref:snapshots-backups/backing-image-backups.adoc[]
 ** xref:snapshots-backups/restore-cluster-rancher-snapshot.adoc[]
+
+// Data Integrity and Recovery Section:
 * Data Integrity and Recovery
 ** xref:data-integrity-recovery/snapshot-data-integrity-check.adoc[]
 ** xref:data-integrity-recovery/orphaned-data-cleanup.adoc[]
@@ -136,16 +164,22 @@
 *** xref:data-integrity-recovery/data-recovery/recover-from-data-errors.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-from-full-disk.adoc[]
 *** xref:data-integrity-recovery/data-recovery/recover-without-system.adoc[]
+
+// Observability Section:
 * Observability
 ** xref:observability/configure-prometheus-grafana.adoc[]
 ** xref:observability/alert-rule-examples.adoc[]
 ** xref:observability/longhorn-metrics.adoc[]
 ** xref:observability/integrate-with-rancher-monitoring.adoc[]
 ** xref:observability/kubelet-volume-metrics.adoc[]
+
+// Troubleshooting and Maintenance Section:
 * Troubleshooting and Maintenance
 ** xref:troubleshooting-maintenance/support-bundle.adoc[]
 ** xref:troubleshooting-maintenance/troubleshooting.adoc[]
 ** xref:troubleshooting-maintenance/v2-data-engine-issues.adoc[]
 ** xref:troubleshooting-maintenance/maintenance.adoc[]
+
+// Glossary Section:
 * Glossary
 ** xref:glossary/glossary.adoc[]

--- a/docs/version-1.9/modules/en/nav.adoc
+++ b/docs/version-1.9/modules/en/nav.adoc
@@ -1,4 +1,4 @@
-// SUSE Storage Longhorn Documentation Section:
+// SUSE Storage Documentation Section:
 * xref:longhorn-documentation.adoc[]
 
 // Release Notes Section:

--- a/docs/version-1.9/modules/en/pages/release-notes/v1.9.1.adoc
+++ b/docs/version-1.9/modules/en/pages/release-notes/v1.9.1.adoc
@@ -23,7 +23,7 @@ For more information, see xref:advanced-resources/data-cleanup.adoc[Orphan Data 
 
 === Deprecated fields in `longhorn.io/v1beta2` CRDs
 
-Deprecated fields have been removed from the CRDs. For details, see https://github.com/longhorn/longhorn/issues/6684[issue #6684].
+Deprecated fields have been removed from the CRDs. For details, see https://github.com/longhorn/longhorn/issues/6684[#6684].
 
 == Deprecations and Incompatibilities
 
@@ -31,7 +31,7 @@ Deprecated fields have been removed from the CRDs. For details, see https://gith
 
 The `v1beta1` version of the {longhorn-product-name} API is marked unserved and unsupported in v1.9.0 and will be removed in v1.10.0.
 
-For more details, see https://github.com/longhorn/longhorn/issues/10250[issue #10250].
+For more details, see https://github.com/longhorn/longhorn/issues/10250[#10250].
 
 === Breaking change in V2 backing image
 
@@ -47,7 +47,7 @@ Starting with {longhorn-product-name} v1.9.0, V2 backing images are incompatible
 ** Recreate the V2 backing images using the same names and image sources.
 ** Restore the volumes from your backups.
 
-For more details, see https://github.com/longhorn/longhorn/issues/10805[issue #10805].
+For more details, see https://github.com/longhorn/longhorn/issues/10805[#10805].
 
 == Primary Highlights
 
@@ -63,13 +63,13 @@ While the V2 Data Engine remains experimental in this release, several core func
 
 Starting with {longhorn-product-name} v1.9.0, you can create a recurring job for system backup creation.
 
-xref:advanced-resources/system-backup-restore/backup-longhorn-system.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6534[GitHub Issue]
+xref:advanced-resources/system-backup-restore/backup-longhorn-system.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6534[#6534]
 
 === Offline replica rebuilding
 
 {longhorn-product-name} introduces offline replica rebuilding, a feature that allows degraded volumes to automatically recover replicas even while the volume is detached. This capability minimizes the need for manual recovery steps, accelerates restoration, and ensures high data availability. By default, offline replica rebuilding is disabled. To enable it, set the `offline-replica-rebuilding` setting to `true` in the {longhorn-product-name} UI or CLI.
 
-xref:advanced-resources/rebuilding/offline-replica-rebuilding.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/8443[GitHub Issue]
+xref:advanced-resources/rebuilding/offline-replica-rebuilding.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/8443[#8443]
 
 === Orphaned instance deletion
 
@@ -77,7 +77,7 @@ xref:advanced-resources/rebuilding/offline-replica-rebuilding.adoc[Documentation
 
 To reduce resource usage and maintain system performance, {longhorn-product-name} supports both automatic and manual cleanup. By default, this feature is disabled. To enable it, set the `orphan-resource-auto-deletion` setting to `instance` in the {longhorn-product-name} UI or CLI.
 
-xref:advanced-resources/data-cleanup/orphaned-instance-cleanup.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6764[GitHub Issue]
+xref:advanced-resources/data-cleanup/orphaned-instance-cleanup.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6764[#6764]
 
 === Improved metrics for replica, engine, and rebuild status
 
@@ -89,7 +89,7 @@ For more information, see https://github.com/longhorn/longhorn/issues/10550[#105
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.1.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.1*.
 ====
 
 You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
@@ -98,16 +98,16 @@ You can install {longhorn-product-name} using a variety of tools, including {ran
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.1) to v1.9.1.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.1) to v1.9.1*.
 ====
 
 {longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
 
-== Post-release known issues
+== Post-release Known Issues
 
 For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
 
-== Resolved issues
+== Resolved Issues
 
 === Feature
 
@@ -127,10 +127,10 @@ For information about issues identified after this release, see https://github.c
 === Bug
 
 * https://github.com/longhorn/longhorn/issues/11266[#11266] [BACKPORT][v1.9.1][BUG] Incorrect value of `remove-snapshots-during-filesystem-trim` in longhorn chart/values.yaml
-* https://github.com/longhorn/longhorn/issues/11258[#11258] [BACKPORT][v1.9.1][BUG] privateRegistry.registryUrl does not work when overriding specific image registries
+* https://github.com/longhorn/longhorn/issues/11258[#11258] [BACKPORT][v1.9.1][BUG] `privateRegistry.registryUrl` does not work when overriding specific image registries
 * https://github.com/longhorn/longhorn/issues/11235[#11235] [BACKPORT][v1.9.1][BUG] system backup error
 * https://github.com/longhorn/longhorn/issues/11184[#11184] [BACKPORT][v1.9.1][BUG] Volume expansion fails with "unsupported disk encryption format Ext4"
-* https://github.com/longhorn/longhorn/issues/11217[#11217] [BACKPORT][v1.9.1][BUG] The Backup YAML example in the Longhorn doc does not work
+* https://github.com/longhorn/longhorn/issues/11217[#11217] [BACKPORT][v1.9.1][BUG] The Backup YAML example in the {longhorn-product-name} doc does not work
 * https://github.com/longhorn/longhorn/issues/11164[#11164] [BACKPORT][v1.9.1][BUG] CSI Plug-in restart triggers unintended restart of migratable RWX volume workloads
 * https://github.com/longhorn/longhorn/issues/11180[#11180] [BACKPORT][v1.9.1][BUG] in the browser UI: Volume - Clone Volume results in the broken browser page
 * https://github.com/longhorn/longhorn/issues/10917[#10917] [BACKPORT][v1.9.1][BUG] Test case `test_engine_image_not_fully_deployed_perform_volume_operations` failed: unable to detach a volume

--- a/docs/version-1.9/modules/en/pages/release-notes/v1.9.1.adoc
+++ b/docs/version-1.9/modules/en/pages/release-notes/v1.9.1.adoc
@@ -1,0 +1,147 @@
+= {longhorn-product-name} v1.9.1 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For more information about release-related terminology, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Removals
+
+=== Environment check script
+
+The `environment_check.sh` script, deprecated in v1.7.0, has been removed in v1.9.0. Use the xref:advanced-resources/longhornctl.adoc[{longhorn-product-name} Command Line Tool] (`longhornctl`) to check your environment for potential issues.
+
+=== Orphan resource auto-deletion
+
+The `orphan-auto-deletion` setting has been replaced by `orphan-resource-auto-deletion` in v1.9.0. To replicate the previous behavior, include `replica-data` in the `orphan-resource-auto-deletion` value. During the upgrade, the original `orphan-auto-deletion` setting is automatically migrated.
+
+For more information, see xref:advanced-resources/data-cleanup.adoc[Orphan Data Cleanup].
+
+=== Deprecated fields in `longhorn.io/v1beta2` CRDs
+
+Deprecated fields have been removed from the CRDs. For details, see https://github.com/longhorn/longhorn/issues/6684[issue #6684].
+
+== Deprecations and Incompatibilities
+
+=== `longhorn.io/v1beta1` API
+
+The `v1beta1` version of the {longhorn-product-name} API is marked unserved and unsupported in v1.9.0 and will be removed in v1.10.0.
+
+For more details, see https://github.com/longhorn/longhorn/issues/10250[issue #10250].
+
+=== Breaking change in V2 backing image
+
+Starting with {longhorn-product-name} v1.9.0, V2 backing images are incompatible with earlier versions due to naming conflicts in the extended attributes (`xattrs`) used by SPDK backing image logical volumes. As a result, V2 backing images must be deleted and recreated during the upgrade process. Since backing images cannot be deleted while volumes using them still exist, you must first back up, delete and later restore those volumes as the following steps:
+
+* Before upgrading to v1.9.0:
+** Verify that backup targets are functioning properly.
+** Create full backups of all volumes that use a V2 backing image.
+** Detach and delete these volumes after the backups complete.
+** In the *Backing Image* page, save the specifications of all V2 backing images, including the name and the image source.
+** Delete all V2 backing images.
+* After upgrading:
+** Recreate the V2 backing images using the same names and image sources.
+** Restore the volumes from your backups.
+
+For more details, see https://github.com/longhorn/longhorn/issues/10805[issue #10805].
+
+== Primary Highlights
+
+=== New V2 Data Engine features
+
+While the V2 Data Engine remains experimental in this release, several core functions have been improved:
+
+* https://github.com/longhorn/longhorn/issues/9719[Support UBLK Frontend]: Support for UBLK front-end in the V2 Data Engine, which allows for better performance and resource utilization.
+* https://github.com/longhorn/longhorn/issues/6450[Storage Network]: Introduces support for storage networks in the V2 Data Engine to allow network segregation.
+* https://github.com/longhorn/longhorn/issues/8443[Offline Replica Rebuilding]: Support for offline replica rebuilding, which allows degraded volumes to automatically recover replicas even while the volume is detached. This capability ensures high data availability without manual intervention.
+
+=== Recurring system backup
+
+Starting with {longhorn-product-name} v1.9.0, you can create a recurring job for system backup creation.
+
+xref:advanced-resources/system-backup-restore/backup-longhorn-system.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6534[GitHub Issue]
+
+=== Offline replica rebuilding
+
+{longhorn-product-name} introduces offline replica rebuilding, a feature that allows degraded volumes to automatically recover replicas even while the volume is detached. This capability minimizes the need for manual recovery steps, accelerates restoration, and ensures high data availability. By default, offline replica rebuilding is disabled. To enable it, set the `offline-replica-rebuilding` setting to `true` in the {longhorn-product-name} UI or CLI.
+
+xref:advanced-resources/rebuilding/offline-replica-rebuilding.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/8443[GitHub Issue]
+
+=== Orphaned instance deletion
+
+{longhorn-product-name} can now track and remove orphaned instances, which are leftover resources like replicas or engines that are no longer associated with an active volume. These instances may accumulate due to unexpected failures or incomplete cleanup.
+
+To reduce resource usage and maintain system performance, {longhorn-product-name} supports both automatic and manual cleanup. By default, this feature is disabled. To enable it, set the `orphan-resource-auto-deletion` setting to `instance` in the {longhorn-product-name} UI or CLI.
+
+xref:advanced-resources/data-cleanup/orphaned-instance-cleanup.adoc[Documentation] | https://github.com/longhorn/longhorn/issues/6764[GitHub Issue]
+
+=== Improved metrics for replica, engine, and rebuild status
+
+{longhorn-product-name} improves observability with new Prometheus metrics that expose the status and identity of Replica and Engine CRs, along with rebuild activity. These metrics make it easier to monitor rebuilds across the cluster.
+
+For more information, see https://github.com/longhorn/longhorn/issues/10550[#10550] and https://github.com/longhorn/longhorn/issues/10722[#10722].
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.1.*
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.1) to v1.9.1.*
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release known issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved issues
+
+=== Feature
+
+* https://github.com/longhorn/longhorn/issues/11068[#11068] [BACKPORT][v1.9.1][FEATURE] Standardized way to override container image registry
+* https://github.com/longhorn/longhorn/issues/11072[#11072] [BACKPORT][v1.9.1][FEATURE] Standardized way to specify image pull secrets
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/11280[#11280] [BACKPORT][v1.9.1][IMPROVEMENT] Remove the Patch `preserveUnknownFields: false` for CRDs
+* https://github.com/longhorn/longhorn/issues/11212[#11212] [BACKPORT][v1.9.1][IMPROVEMENT] Improve the disk space un-schedulable condition message
+* https://github.com/longhorn/longhorn/issues/11196[#11196] [BACKPORT][v1.9.1][IMPROVEMENT] Improve the condition message of engine image check
+* https://github.com/longhorn/longhorn/issues/11225[#11225] [BACKPORT][v1.9.1][IMPROVEMENT] Improve the logging when detecting multiple backup volumes of the same volume on the same backup target
+* https://github.com/longhorn/longhorn/issues/11168[#11168] [BACKPORT][v1.9.1][IMPROVEMENT] extra invalid BackupVolumeCR may be created during cluster split-brain
+* https://github.com/longhorn/longhorn/issues/11069[#11069] [BACKPORT][v1.9.1][IMPROVEMENT] Full replica rebuilding when a node goes down for a while and then comes back
+* https://github.com/longhorn/longhorn/issues/10914[#10914] [BACKPORT][v1.9.1][IMPROVEMENT] Adding retry logic for `longhorn-csi-plugin` when it trying to contact the longhorn-manager pods
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/11266[#11266] [BACKPORT][v1.9.1][BUG] Incorrect value of `remove-snapshots-during-filesystem-trim` in longhorn chart/values.yaml
+* https://github.com/longhorn/longhorn/issues/11258[#11258] [BACKPORT][v1.9.1][BUG] privateRegistry.registryUrl does not work when overriding specific image registries
+* https://github.com/longhorn/longhorn/issues/11235[#11235] [BACKPORT][v1.9.1][BUG] system backup error
+* https://github.com/longhorn/longhorn/issues/11184[#11184] [BACKPORT][v1.9.1][BUG] Volume expansion fails with "unsupported disk encryption format Ext4"
+* https://github.com/longhorn/longhorn/issues/11217[#11217] [BACKPORT][v1.9.1][BUG] The Backup YAML example in the Longhorn doc does not work
+* https://github.com/longhorn/longhorn/issues/11164[#11164] [BACKPORT][v1.9.1][BUG] CSI Plug-in restart triggers unintended restart of migratable RWX volume workloads
+* https://github.com/longhorn/longhorn/issues/11180[#11180] [BACKPORT][v1.9.1][BUG] in the browser UI: Volume - Clone Volume results in the broken browser page
+* https://github.com/longhorn/longhorn/issues/10917[#10917] [BACKPORT][v1.9.1][BUG] Test case `test_engine_image_not_fully_deployed_perform_volume_operations` failed: unable to detach a volume
+* https://github.com/longhorn/longhorn/issues/11170[#11170] [BACKPORT][v1.9.1][BUG] Creating support-bundle panic NPE
+* https://github.com/longhorn/longhorn/issues/11162[#11162] [BACKPORT][v1.9.1][BUG] Unable to Build Longhorn-Share-Manager Image Due to CMAKE Compatibility
+* https://github.com/longhorn/longhorn/issues/11020[#11020] [BACKPORT][v1.9.1][BUG] Recurring jobs fail when assigned to default group
+* https://github.com/longhorn/longhorn/issues/11047[#11047] [BACKPORT][v1.9.1][BUG] SPDK API `bdev_lvol_detach_parent` does not work as expected
+* https://github.com/longhorn/longhorn/issues/11056[#11056] [BACKPORT][v1.9.1][BUG] unable to clean up the backing image volume replica after node eviction
+* https://github.com/longhorn/longhorn/issues/11035[#11035] [BACKPORT][v1.9.1][BUG] backing image volume replica NPE crash during evicting node
+
+== Misc
+
+* https://github.com/longhorn/longhorn/issues/11140[#11140] [HOTFIX] Create hotfixed image for `longhorn-manager:v1.9.0`
+* https://github.com/longhorn/longhorn/issues/11118[#11118] [BACKPORT][v1.9.1][TASK] Ensure support-bundle-kit builds use vendored dependencies

--- a/docs/version-1.9/modules/en/pages/release-notes/v1.9.2.adoc
+++ b/docs/version-1.9/modules/en/pages/release-notes/v1.9.2.adoc
@@ -13,7 +13,7 @@ For more information about release-related terminology, see https://github.com/l
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.2.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.2*.
 ====
 
 You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
@@ -22,16 +22,16 @@ You can install {longhorn-product-name} using a variety of tools, including {ran
 
 [IMPORTANT]
 ====
-*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.2) to v1.9.2.*
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.2) to v1.9.2*.
 ====
 
 {longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
 
-== Post-release known issues
+== Post-release Known Issues
 
 For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
 
-== Resolved issues
+== Resolved Issues
 
 === Improvement
 
@@ -53,17 +53,17 @@ For information about issues identified after this release, see https://github.c
 
 * https://github.com/longhorn/longhorn/issues/11788[#11788] [BACKPORT][v1.9.2][BUG] Potential Data Corruption During Volume Resizing When Created from Snapshot
 * https://github.com/longhorn/longhorn/issues/11744[#11744] [BUG] [v1.9.x] support bundle stuck at 33%
-* https://github.com/longhorn/longhorn/issues/11639[#11639] [BACKPORT][v1.9.2][BUG] Unable to disable v2-data-engine even though there is no v2 volumes, backing images or orphaned data
-* https://github.com/longhorn/longhorn/issues/11722[#11722] [BACKPORT][v1.9.2][BUG] Longhorn pvcs are in pending state.
+* https://github.com/longhorn/longhorn/issues/11639[#11639] [BACKPORT][v1.9.2][BUG] Unable to disable v2-data-engine even though there is no V2 volumes, backing images or orphaned data
+* https://github.com/longhorn/longhorn/issues/11722[#11722] [BACKPORT][v1.9.2][BUG] {longhorn-product-name} pvcs are in pending state.
 * https://github.com/longhorn/longhorn/issues/11729[#11729] [BUG] Broken link in documentation
-* https://github.com/longhorn/longhorn/issues/11710[#11710] [BACKPORT][v1.9.2][BUG] longhornctl preflight install should load and check iscsi_tcp kernel module.
+* https://github.com/longhorn/longhorn/issues/11710[#11710] [BACKPORT][v1.9.2][BUG] longhornctl preflight install should load and check `iscsi_tcp` kernel module.
 * https://github.com/longhorn/longhorn/issues/11624[#11624] [BACKPORT][v1.9.2][BUG] Backing image download gets stuck after network disconnection
 * https://github.com/longhorn/longhorn/issues/11341[#11341] [BACKPORT][v1.9.2][BUG] Volume becomes faulted when its replica node disks run out of space during a write operation
 * https://github.com/longhorn/longhorn/issues/11606[#11606] [BACKPORT][v1.9.2][BUG] Engine process continues running after rapid volume detachment
 * https://github.com/longhorn/longhorn/issues/11648[#11648] [BACKPORT][v1.9.2][BUG] Creating a 2 Gi volume with a 200 Mi backing image is rejected with “volume size should be larger than the backing image size”
 * https://github.com/longhorn/longhorn/issues/11599[#11599] [BACKPORT][v1.9.2][BUG] longhorn-manager repeatedly emits `No instance manager for node xxx for update instance state of orphan instance orphan-xxx..`
 * https://github.com/longhorn/longhorn/issues/11692[#11692] [BACKPORT][v1.9.2][BUG] BackupBackingImage may be created from an unready BackingImageManager
-* https://github.com/longhorn/longhorn/issues/11570[#11570] [BACKPORT][v1.9.2][BUG] Longhorn fails to create Backing Image Backup on ARM platform
+* https://github.com/longhorn/longhorn/issues/11570[#11570] [BACKPORT][v1.9.2][BUG] {longhorn-product-name} fails to create Backing Image Backup on ARM platform
 * https://github.com/longhorn/longhorn/issues/11614[#11614] [BACKPORT][v1.9.2][BUG] remaining unknown OS condition in node CR
 * https://github.com/longhorn/longhorn/issues/11584[#11584] [BACKPORT][v1.9.2][BUG] Volumes fails to remount when they go read-only
 * https://github.com/longhorn/longhorn/issues/11590[#11590] [BACKPORT][v1.9.2][BUG] Dangling Volume State When Live Migration Terminates Unexpectedly

--- a/docs/version-1.9/modules/en/pages/release-notes/v1.9.2.adoc
+++ b/docs/version-1.9/modules/en/pages/release-notes/v1.9.2.adoc
@@ -1,0 +1,77 @@
+= {longhorn-product-name} v1.9.2 Release Notes
+:revdate: 2026-08-03
+:page-revdate: {revdate}
+
+This release introduces several improvements and bug fixes that are intended to improve system quality, resilience, stability and security. The documentation is available at xref:introduction/overview.adoc[{longhorn-product-name} Documentation].
+
+[NOTE]
+====
+For more information about release-related terminology, see https://github.com/longhorn/longhorn#releases[Releases].
+====
+
+== Installation
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before installing {longhorn-product-name} v1.9.2.*
+====
+
+You can install {longhorn-product-name} using a variety of tools, including {rancher-product-name-tm}, Kubectl, and Helm. For more information about installation methods and requirements, see xref:deploy/install.adoc[Quick Installation] in the documentation.
+
+== Upgrade
+
+[IMPORTANT]
+====
+*Ensure that your cluster is running Kubernetes v1.25 or later before upgrading from {longhorn-product-name} v1.8.x or v1.9.x (< v1.9.2) to v1.9.2.*
+====
+
+{longhorn-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see xref:deploy/upgrade.adoc[Upgrade] in the documentation.
+
+== Post-release known issues
+
+For information about issues identified after this release, see https://github.com/longhorn/longhorn/wiki/Release-Known-Issues[Release-Known-Issues].
+
+== Resolved issues
+
+=== Improvement
+
+* https://github.com/longhorn/longhorn/issues/11805[#11805] [BACKPORT][v1.9.2][IMPROVEMENT] Add usage metrics for Longhorn installation variant
+* https://github.com/longhorn/longhorn/issues/11782[#11782] [BACKPORT][v1.9.2][IMPROVEMENT] SAST Potential dereference of the null pointer in controller/volume_controller.go in longhorn-manager
+* https://github.com/longhorn/longhorn/issues/11726[#11726] [BACKPORT][v1.9.2][IMPROVEMENT] Collect mount table, process status and process table in support bundle
+* https://github.com/longhorn/longhorn/issues/11567[#11567] [BACKPORT][v1.9.2][IMPROVEMENT] rename the backing image manager to reduce the probability of CR name collision
+* https://github.com/longhorn/longhorn/issues/11604[#11604] [BACKPORT][v1.9.2][IMPROVEMENT] Improve log messages of longhorn-engine, tgt and liblonghorn for troubleshooting
+* https://github.com/longhorn/longhorn/issues/11501[#11501] [BACKPORT][v1.9.2][IMPROVEMENT] Misleading log message `Deleting orphans on evicted node ...`
+* https://github.com/longhorn/longhorn/issues/11324[#11324] [BACKPORT][v1.9.2][IMPROVEMENT] Check if the backup target is available before creating a backup, backup backing image, and system backup
+* https://github.com/longhorn/longhorn/issues/11310[#11310] [BACKPORT][v1.9.2][IMPROVEMENT] adjust the hardcoded timeout limitation for backing image downloading
+* https://github.com/longhorn/longhorn/issues/11508[#11508] [BACKPORT][v1.9.2][IMPROVEMENT] Improve longhorn-engine controller log messages
+* https://github.com/longhorn/longhorn/issues/11506[#11506] [BACKPORT][v1.9.2][IMPROVEMENT] Make liveness probe parameters of instance-manager pod configurable
+* https://github.com/longhorn/longhorn/issues/11488[#11488] [BACKPORT][v1.9.2][IMPROVEMENT] backing image handle node disk deleting events
+* https://github.com/longhorn/longhorn/issues/11327[#11327] [BACKPORT][v1.9.2][IMPROVEMENT] Handle credential secret containing mixed invalid conditions
+* https://github.com/longhorn/longhorn/issues/11193[#11193] [BACKPORT][v1.9.2][IMPROVEMENT] Improve the condition message of engine image check
+
+=== Bug
+
+* https://github.com/longhorn/longhorn/issues/11788[#11788] [BACKPORT][v1.9.2][BUG] Potential Data Corruption During Volume Resizing When Created from Snapshot
+* https://github.com/longhorn/longhorn/issues/11744[#11744] [BUG] [v1.9.x] support bundle stuck at 33%
+* https://github.com/longhorn/longhorn/issues/11639[#11639] [BACKPORT][v1.9.2][BUG] Unable to disable v2-data-engine even though there is no v2 volumes, backing images or orphaned data
+* https://github.com/longhorn/longhorn/issues/11722[#11722] [BACKPORT][v1.9.2][BUG] Longhorn pvcs are in pending state.
+* https://github.com/longhorn/longhorn/issues/11729[#11729] [BUG] Broken link in documentation
+* https://github.com/longhorn/longhorn/issues/11710[#11710] [BACKPORT][v1.9.2][BUG] longhornctl preflight install should load and check iscsi_tcp kernel module.
+* https://github.com/longhorn/longhorn/issues/11624[#11624] [BACKPORT][v1.9.2][BUG] Backing image download gets stuck after network disconnection
+* https://github.com/longhorn/longhorn/issues/11341[#11341] [BACKPORT][v1.9.2][BUG] Volume becomes faulted when its replica node disks run out of space during a write operation
+* https://github.com/longhorn/longhorn/issues/11606[#11606] [BACKPORT][v1.9.2][BUG] Engine process continues running after rapid volume detachment
+* https://github.com/longhorn/longhorn/issues/11648[#11648] [BACKPORT][v1.9.2][BUG] Creating a 2 Gi volume with a 200 Mi backing image is rejected with “volume size should be larger than the backing image size”
+* https://github.com/longhorn/longhorn/issues/11599[#11599] [BACKPORT][v1.9.2][BUG] longhorn-manager repeatedly emits `No instance manager for node xxx for update instance state of orphan instance orphan-xxx..`
+* https://github.com/longhorn/longhorn/issues/11692[#11692] [BACKPORT][v1.9.2][BUG] BackupBackingImage may be created from an unready BackingImageManager
+* https://github.com/longhorn/longhorn/issues/11570[#11570] [BACKPORT][v1.9.2][BUG] Longhorn fails to create Backing Image Backup on ARM platform
+* https://github.com/longhorn/longhorn/issues/11614[#11614] [BACKPORT][v1.9.2][BUG] remaining unknown OS condition in node CR
+* https://github.com/longhorn/longhorn/issues/11584[#11584] [BACKPORT][v1.9.2][BUG] Volumes fails to remount when they go read-only
+* https://github.com/longhorn/longhorn/issues/11590[#11590] [BACKPORT][v1.9.2][BUG] Dangling Volume State When Live Migration Terminates Unexpectedly
+* https://github.com/longhorn/longhorn/issues/11482[#11482] [BACKPORT][v1.9.2][BUG] Unable to setup backup target in storage network environment: cannot find a running instance manager for node
+* https://github.com/longhorn/longhorn/issues/11476[#11476] [BACKPORT][v1.9.2][BUG] Test case `test_recurring_jobs_when_volume_detached_unexpectedly` failed: backup completed but progress did not reach 100%
+* https://github.com/longhorn/longhorn/issues/11494[#11494] [BACKPORT][v1.9.2][BUG] Recurring Job with 'default' group causes goroutine deadlock on v1.9.1 (Regression of #11020)
+* https://github.com/longhorn/longhorn/issues/11391[#11391] [BACKPORT][v1.9.2][BUG] Test Case `test_replica_auto_balance_node_least_effort` Is Sometimes Failed
+* https://github.com/longhorn/longhorn/issues/11344[#11344] [BACKPORT][v1.9.2][BUG] Unable to set up S3 backup target if backups already exist
+* https://github.com/longhorn/longhorn/issues/11422[#11422] [BACKPORT][v1.9.2][BUG] longhorn-manager is crashed due to `SIGSEGV: segmentation violation`
+* https://github.com/longhorn/longhorn/issues/11382[#11382] [BACKPORT][v1.9.2][BUG] Typo in configuration parameter: "offlineRelicaRebuilding" should be "offlineReplicaRebuilding"
+* https://github.com/longhorn/longhorn/issues/11841[#11841] [BUG][UI][v1.9.2-rc2] Unable to Retrieve Volume's Backup List in the Operation


### PR DESCRIPTION
- Added a "Release Notes" section at the beginning of each doc.
- Created a dedicated file for each release.
- For `x.y.1`: Ported all content + ("Highlights" and "Removal") content from the corresponding `x.y.0` release.
- For `x.y.2`:  Ported all content.
- [Reference](https://github.com/longhorn/longhorn/tree/master/CHANGELOG).